### PR TITLE
Fixed HH:MM:SS time formatting

### DIFF
--- a/singletons/utils.js
+++ b/singletons/utils.js
@@ -317,7 +317,7 @@ module.exports = (function (Module) {
 					seconds -= (hr * Utils.timeUnits.h.s);
 				}
 				const min = Math.floor(seconds / Utils.timeUnits.m.s);
-				stuff.push(min);
+				stuff.push(stuff.length ? this.zf(min, 2) : min);
 				seconds -= (min * Utils.timeUnits.m.s);
 				stuff.push(this.zf(seconds, 2));
 

--- a/singletons/utils.js
+++ b/singletons/utils.js
@@ -317,7 +317,7 @@ module.exports = (function (Module) {
 					seconds -= (hr * Utils.timeUnits.h.s);
 				}
 				const min = Math.floor(seconds / Utils.timeUnits.m.s);
-				stuff.push(stuff.length ? this.zf(min, 2) : min);
+				stuff.push((stuff.length) ? this.zf(min, 2) : min);
 				seconds -= (min * Utils.timeUnits.m.s);
 				stuff.push(this.zf(seconds, 2));
 


### PR DESCRIPTION
Until now it used to be `H:M:SS`, since there was no padding for minutes. Now, Function now adds padding if there are more units on the left. Right now it's only hours, but there might be more things if you consider adding days, etc. later.

Should fix some weird edge cases like this: https://cdn.zneix.eu/idWdmBu.png
![ifyoureadthisivonzulul](https://cdn.zneix.eu/idWdmBu.png)