### PR TITLE
Add evalDiceRoll to sb.Utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "cheerio": "latest",
     "chrono-node": "^1.4.6",
     "cron": "latest",
+    "dice-roll-eval": "github:jprochazk/dice-roll-eval",
     "duration-parser": "github:supinic/duration-parser",
     "ffprobe": "^1.1.0",
     "form-data": "^3.0.0",

--- a/singletons/utils.js
+++ b/singletons/utils.js
@@ -1194,19 +1194,19 @@ module.exports = (function (Module) {
 			}
 
 			return result;
-        }
+		}
 
-        /**
-         * Evaluates an expression in standard dice notation form
-         * 
-         * @param {string} input
-         * @param {number} limit max number of rolls in a single evaluation. Defaults to 10.
-         * @returns {number}
-         * @throws {Error}
-         */
-        evalDiceRoll(input, limit = 10) {
-            return diceRollEval(input, limit, (min, max) => sb.Utils.random(min, max));
-        }
+		/**
+		 * Evaluates an expression in standard dice notation form
+		 * 
+		 * @param {string} input
+		 * @param {number} limit max number of rolls in a single evaluation. Defaults to 10.
+		 * @returns {number}
+		 * @throws {Error}
+		 */
+		evalDiceRoll(input, limit = 10) {
+			return diceRollEval(input, limit, (min, max) => sb.Utils.random(min, max));
+		}
 
 		get modulePath () { return "utils"; }
 

--- a/singletons/utils.js
+++ b/singletons/utils.js
@@ -5,8 +5,8 @@ module.exports = (function (Module) {
 	const RandomJS = require("random-js");
 	const { parse: urlParser } = require("url");
 	const parseDuration = require("duration-parser");
-    const ffprobe = require("ffprobe");
-    const diceRollEval = require("dice-roll-eval");
+	const ffprobe = require("ffprobe");
+	const diceRollEval = require("dice-roll-eval");
 
 	const byteUnits = {
 		si: {
@@ -1200,11 +1200,11 @@ module.exports = (function (Module) {
          * Evaluates an expression in standard dice notation form
          * 
          * @param {string} input
-         * @param {number} limit max number of rolls in a single evaluation
+         * @param {number} limit max number of rolls in a single evaluation. Defaults to 10.
          * @returns {number}
          * @throws {Error}
          */
-        evalDiceRoll(input, limit) {
+        evalDiceRoll(input, limit = 10) {
             return diceRollEval(input, limit, (min, max) => sb.Utils.random(min, max));
         }
 

--- a/singletons/utils.js
+++ b/singletons/utils.js
@@ -5,7 +5,8 @@ module.exports = (function (Module) {
 	const RandomJS = require("random-js");
 	const { parse: urlParser } = require("url");
 	const parseDuration = require("duration-parser");
-	const ffprobe = require("ffprobe");
+    const ffprobe = require("ffprobe");
+    const diceRollEval = require("dice-roll-eval");
 
 	const byteUnits = {
 		si: {
@@ -1193,7 +1194,19 @@ module.exports = (function (Module) {
 			}
 
 			return result;
-		}
+        }
+
+        /**
+         * Evaluates an expression in standard dice notation form
+         * 
+         * @param {string} input
+         * @param {number} limit max number of rolls in a single evaluation
+         * @returns {number}
+         * @throws {Error}
+         */
+        evalDiceRoll(input, limit) {
+            return diceRollEval(input, limit, (min, max) => sb.Utils.random(min, max));
+        }
 
 		get modulePath () { return "utils"; }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,7 +439,7 @@ denque@^1.1.0, denque@^1.4.1:
 
 "dice-roll-eval@github:jprochazk/dice-roll-eval":
   version "1.0.0"
-  resolved "https://codeload.github.com/jprochazk/dice-roll-eval/tar.gz/44c72e1b9630c50251e6e21ce8699e1c0dc1773b"
+  resolved "https://codeload.github.com/jprochazk/dice-roll-eval/tar.gz/1a9a5ca0344d99e20b158a62de6c5d8b4762896c"
 
 diff@4.0.2:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,6 +437,10 @@ denque@^1.1.0, denque@^1.4.1:
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
   integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
+"dice-roll-eval@github:jprochazk/dice-roll-eval":
+  version "1.0.0"
+  resolved "https://codeload.github.com/jprochazk/dice-roll-eval/tar.gz/44c72e1b9630c50251e6e21ce8699e1c0dc1773b"
+
 diff@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"


### PR DESCRIPTION
Addresses the first point from https://github.com/Supinic/supibot-package-manager/pull/24#pullrequestreview-506124341.

Adds https://github.com/jprochazk/dice-roll-eval as a dependency, and exposes it through the sb.Utils singleton.