### PR TITLE
Add custom maraidb port support

### DIFF
--- a/singletons/query/index.js
+++ b/singletons/query/index.js
@@ -62,6 +62,7 @@ module.exports = (function () {
 				this.pool = Maria.createPool({
 					user: process.env.MARIA_USER,
 					host: process.env.MARIA_HOST,
+					port: process.env.MARIA_PORT ?? 3306,
 					password: process.env.MARIA_PASSWORD,
 					connectionLimit: process.env.MARIA_CONNECTION_LIMIT || 300,
 					multipleStatements: true,


### PR DESCRIPTION
Adds optional custom mariadb port, otherwise default port it used. (3306) see supinic/supibot#15 for corresponding pr that sets up this env variable