### PR TITLE
Fix port (possibly) being empty string when no port set up

### DIFF
--- a/singletons/query/index.js
+++ b/singletons/query/index.js
@@ -62,7 +62,7 @@ module.exports = (function () {
 				this.pool = Maria.createPool({
 					user: process.env.MARIA_USER,
 					host: process.env.MARIA_HOST,
-					port: process.env.MARIA_PORT ?? 3306,
+					port: process.env.MARIA_PORT || 3306,
 					password: process.env.MARIA_PASSWORD,
 					connectionLimit: process.env.MARIA_CONNECTION_LIMIT || 300,
 					multipleStatements: true,

--- a/singletons/query/index.js
+++ b/singletons/query/index.js
@@ -62,6 +62,7 @@ module.exports = (function () {
 				this.pool = Maria.createPool({
 					user: process.env.MARIA_USER,
 					host: process.env.MARIA_HOST,
+					port: process.env.MARIA_PORT ?? 3306,
 					password: process.env.MARIA_PASSWORD,
 					connectionLimit: process.env.MARIA_CONNECTION_LIMIT || 300,
 					multipleStatements: true,


### PR DESCRIPTION
Now using `||` instead of `??` because `??` only falls back when undefined or null.