### PR TITLE
Consider usernames prefixed with '.' when trying to apply unping filter

### DIFF
--- a/classes/filter.js
+++ b/classes/filter.js
@@ -630,7 +630,7 @@ module.exports = class Filter extends require("./template.js") {
 		let { string } = options;
 		const unpingUsers = await sb.User.getMultiple(filters.map(i => i.User_Alias));
 		for (const user of unpingUsers) {
-			const regex = new RegExp(String.raw `(^|[@#,:;\s]+)(${user.Name})([?!.,:;\s]|$)`, "gi");
+			const regex = new RegExp(String.raw `(^|[@#.,:;\s]+)(${user.Name})([?!.,:;\s]|$)`, "gi");
 			string = string.replace(regex, (match, prefix, name, suffix) => (
 				`${prefix}${name[0]}\u{E0000}${name.slice(1)}${suffix}`
 			));


### PR DESCRIPTION
Currently users can craft command invocations that print `.tetyys` (in my case) which will ping me and don't get caught by unping filter. This PR adds a dot in regex which fixes that