### PR TITLE
fix(objects/date): return correct suffix on the 21st, 22nd, 23rd, and 31st

### DIFF
--- a/objects/date.js
+++ b/objects/date.js
@@ -23,17 +23,19 @@ module.exports = class Date extends global.Date {
 			throw new Error("Input must be an integer");
 		}
 
-		if (number === 1) {
-			return "st";
-		}
-		else if (number === 2) {
-			return "nd";
-		}
-		else if (number === 3) {
-			return "rd";
-		}
-		else {
-			return "th";
+		switch (number) {
+			case 1:
+			case 21:
+			case 31:
+				return "st";
+			case 2:
+			case 22:
+				return "nd";
+			case 3:
+			case 23:
+				return "rd";
+			default:
+				return "th";
 		}
 	}
 


### PR DESCRIPTION
Currently `sb.Date#format("S")` will return 22th or 31th on the respective days. This PR attempts to fix this.

I could add tests (for the entire sb.Date) in a followup PR.

![FarmingCommits](https://cdn.betterttv.net/emote/5ed57f8bfdee545e3065efcb/2x)