### PR TITLE
Custom initialize and destroy methods for commands

### DIFF
--- a/@types/classes/command.d.ts
+++ b/@types/classes/command.d.ts
@@ -461,6 +461,23 @@ export declare class Command extends ClassTemplate {
      */
     #Author: string | null;
 
+    /**
+     * Determines whether or not the command's initialization has already passed.
+     * If a command is not ready (the value is `false`), its code execution will always return `undefined` rather than running its code.
+     */
+    #ready: boolean;
+
+    /**
+     * Determines whether or not the command has already been destroyed.
+     * If a command is destroyed (the value is `true`), its code execution will always return `undefined` rather than running its code.
+     */
+    #destroyed: boolean;
+
+    /**
+     * Custom `destroy` method to be run during the command's `destroy()` call.
+     */
+    #customDestroy: () => Promise<void> | null;
+
     constructor (data: ConstructorData);
 
     /**


### PR DESCRIPTION
This would allow proper initialization and destruction of commands' data and related things in a separate method rather than relying on initializing them in proper code, or relying on shoddily constructed `staticData` that contain `destroy` methods.

As a next step after this refactor, the `staticData.destroy` methods should be hastily removed, and then, the entire concept of `staticData` needs to be revisited and ideally removed.