### PR TITLE
Convert to `.mjs` syntax

### DIFF
--- a/@types/classes/config.d.ts
+++ b/@types/classes/config.d.ts
@@ -1,11 +1,11 @@
-import { CustomDate as Date } from "../objects/date";
-import { SimpleGenericData } from "../globals";
+import type { SupiDate } from "../objects/date.d.ts";
+import type { SimpleGenericData } from "../globals.d.ts";
 
 export declare type Name = string;
 
 // @todo get rid of the function type and value
 export declare type Type = "number" | "string" | "array" | "object" | "date" | "regex" | "boolean" | "function";
-export declare type Value = boolean | number | string | any[] | SimpleGenericData | Date | RegExp | ((...args: any[]) => any);
+export declare type Value = boolean | number | string | any[] | SimpleGenericData | SupiDate | RegExp | ((...args: any[]) => any);
 export declare type Representation = {
     name: Name;
     type: Type;
@@ -49,7 +49,7 @@ export declare class Config {
      * @param variable Variable name
      * @param strict If true, the config variable must exist, otherwise an error is thrown. If false,
      * then undefined is return - should the variable not exist.
-     * @throws {sb.Error} If variable does not exist and `strict` is true
+     * @throws {SupiError} If variable does not exist and `strict` is true
      */
     static get (variable: string, strict?: boolean): Value;
 
@@ -57,9 +57,9 @@ export declare class Config {
      * Sets the configuration variable
      * @param variable Variable name
      * @param value New variable value
-     * @throws {sb.Error} If variable does not exist
-     * @throws {sb.Error} If variable is not editable
-     * @throws {sb.Error} If provided value type is incompatible with the variable type
+     * @throws {SupiError} If variable does not exist
+     * @throws {SupiError} If variable is not editable
+     * @throws {SupiError} If provided value type is incompatible with the variable type
      */
     static set (variable: string, value: Value): Promise<void>;
 

--- a/@types/classes/config.d.ts
+++ b/@types/classes/config.d.ts
@@ -1,35 +1,41 @@
 import { CustomDate as Date } from "../objects/date";
 import { SimpleGenericData } from "../globals";
 
-export declare type ConstructorData = {
-    Name: string;
-    Type: Type;
-    Unit: Unit | null;
-    Secret: boolean;
-    Editable: boolean;
-    Value: string | Value;
-};
 export declare type Name = string;
+
+// @todo get rid of the function type and value
 export declare type Type = "number" | "string" | "array" | "object" | "date" | "regex" | "boolean" | "function";
 export declare type Value = boolean | number | string | any[] | SimpleGenericData | Date | RegExp | ((...args: any[]) => any);
-export declare type Unit = "s" | "ms";
 export declare type Representation = {
     name: Name;
     type: Type;
     value: Value;
+};
+export declare type ConstructorData = {
+    Name: Name;
+    Type: Type;
+    Secret: boolean;
+    Editable: boolean;
+    Value: string | Value;
 };
 
 /**
  * Represents configuration variables saved in the database.
  */
 export declare class Config {
-    static data: Map<string, Config>;
-    static nonStrictNotifications: Map<string, true>;
+    static data: Map<Name, Config>;
 
     /**
      * Creates a Config instance based on provided representation.
      */
     static from (data: Representation): Config;
+
+    /**
+     * Loads and fills the Config variables based on provided data.
+     * If `options.keepNotLoaded` is `true`, config variables that have not been loaded in this call will be kept.
+     * Otherwise, they will be cleared as in a full reload.
+     */
+    static load (data: ConstructorData[], options?: { keepNotLoaded: boolean }): void;
 
     /**
      * Checks if given configuration variable exists.
@@ -57,17 +63,16 @@ export declare class Config {
      */
     static set (variable: string, value: Value): Promise<void>;
 
-    #Name: string;
+    #Name: Name;
     #Value: Value;
     #Type: Type;
-    #Unit: Unit | null;
     #Secret: boolean;
     #Editable: boolean;
     #initialized: boolean;
 
     constructor (data: ConstructorData);
 
-    get name (): string;
+    get name (): Name;
     get editable (): boolean;
     get value (): Value;
     get stringValue (): string;

--- a/@types/classes/config.d.ts
+++ b/@types/classes/config.d.ts
@@ -14,7 +14,6 @@ export declare type Representation = {
 export declare type ConstructorData = {
     Name: Name;
     Type: Type;
-    Secret: boolean;
     Editable: boolean;
     Value: string | Value;
 };
@@ -66,7 +65,6 @@ export declare class Config {
     #Name: Name;
     #Value: Value;
     #Type: Type;
-    #Secret: boolean;
     #Editable: boolean;
     #initialized: boolean;
 

--- a/@types/classes/got-proxy.d.ts
+++ b/@types/classes/got-proxy.d.ts
@@ -1,6 +1,6 @@
 import { ExtendOptions, Got, InternalsType, GotReturn } from "got";
 import { URL } from "url";
-import FormData = require("form-data");
+import FormData from "form-data";
 
 export { Got } from "got";
 

--- a/@types/classes/got-proxy.d.ts
+++ b/@types/classes/got-proxy.d.ts
@@ -51,7 +51,6 @@ declare class StaticGot {
 	static extend (extendOptions: ExtendOptions): Extension;
 	static isRequestError (error: Error): boolean;
 
-	static get specificName (): "Got";
 	static get FormData (): FormData;
 }
 

--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -1,28 +1,18 @@
 export declare type Message = string;
-export declare type Emote = {
-    ID: string;
-    name: string;
-    type: "twitch-subscriber" | "twitch-global" | "ffz" | "bttv" | "7tv";
-    global: boolean;
-    animated: boolean | null;
-};
 export declare type Port = number;
 export declare type URL = string;
 export declare type Stringifiable = boolean | number | string;
 export declare type JSONifiable = null | boolean | number | string | { [P: string]: JSONifiable } | JSONifiable[];
 export declare type SimpleGenericData = Record<string, JSONifiable>;
-export declare interface GenericFlagsObject {
-    [key: string]: boolean
-}
-export declare type Without<T, U> = {
-    [P in Exclude<keyof T, keyof U>]?: never
-};
-export declare type XOR <T, U> = (T | U) extends object
-    ? (Without<T, U> & U) | (Without<U, T> & T)
-    : T | U;
-export declare type OnlyKeysOfType<T, U> = {
-    [P in keyof T]: T[P] extends U ? P : never
-}[keyof T];
-export declare type TypeExtract<T, U> = {
-    [P in OnlyKeysOfType<T, U>]: U;
-};
+// export declare type Without<T, U> = {
+//     [P in Exclude<keyof T, keyof U>]?: never
+// };
+// export declare type XOR <T, U> = (T | U) extends object
+//     ? (Without<T, U> & U) | (Without<U, T> & T)
+// //     : T | U;
+// export declare type OnlyKeysOfType<T, U> = {
+//     [P in keyof T]: T[P] extends U ? P : never
+// }[keyof T];
+// export declare type TypeExtract<T, U> = {
+//     [P in OnlyKeysOfType<T, U>]: U;
+// };

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,14 +1,25 @@
-// objects
-export type * as Date from "./objects/date.d.ts";
-export type * as Error from "./objects/error.d.ts";
-export type * as Promise from "./objects/promise.d.ts";
+import type { SupiDate as Date } from "./objects/date.d.ts";
+import type { SupiError as Error } from "./objects/error.d.ts";
+import type { SupiPromise as Promise } from "./objects/promise.d.ts";
 
-// classes
-export type * as Config from "./classes/config.d.ts";
-export type * as Got from "./classes/got-proxy.d.ts";
+import type { Query } from "./singletons/query/index.d.ts";
+import type { Cache } from "./singletons/cache.d.ts";
+import type { Metrics } from "./singletons/metrics.d.ts";
+import type { Utils } from "./singletons/utils.d.ts";
 
-// singletons
-export type * as Cache from "./singletons/cache.d.ts";
-export type * as Metrics from "./singletons/metrics.d.ts";
-export type * as Query from "./singletons/query/index.d.ts";
-export type * as Utils from "./singletons/utils.d.ts";
+import type { Config } from "./classes/config.d.ts";
+import type { Got } from "./classes/got-proxy.d.ts";
+
+export {
+    Date,
+    Error,
+    Promise,
+
+    Config,
+    Got,
+
+    Query,
+    Cache,
+    Metrics,
+    Utils
+};

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -8,7 +8,7 @@ import type { Metrics } from "./singletons/metrics.d.ts";
 import type { Utils } from "./singletons/utils.d.ts";
 
 import type { Config } from "./classes/config.d.ts";
-import type { Got } from "./classes/got-proxy.d.ts";
+import type { GotProxy as Got } from "./classes/got-proxy.d.ts";
 
 export {
     Date,

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,62 +1,14 @@
 // objects
-import { CustomDate } from "./objects/date";
-import { CustomError } from "./objects/error";
-import { CustomPromise } from "./objects/promise";
-
-export * as Date from "./objects/date";
-export * as Error from "./objects/error";
-export * as Promise from "./objects/promise";
+export type * as Date from "./objects/date.d.ts";
+export type * as Error from "./objects/error.d.ts";
+export type * as Promise from "./objects/promise.d.ts";
 
 // classes
-import { Config } from "./classes/config";
-import { GotProxy as Got } from "./classes/got";
-
-export * as Config from "./classes/config";
-export * as Got from "./classes/got";
+export type * as Config from "./classes/config.d.ts";
+export type * as GotProxy from "./classes/got-proxy.d.ts";
 
 // singletons
-import { CacheSingleton } from "./singletons/cache";
-import { MetricsSingleton } from "./singletons/metrics";
-import { QuerySingleton } from "./singletons/query";
-import { UtilsSingleton } from "./singletons/utils";
-
-export * as Cache from "./singletons/cache";
-export * as Metrics from "./singletons/metrics";
-export * as Query from "./singletons/query";
-export * as Utils from "./singletons/utils";
-
-export declare type GlobalSbObject = {
-    Date: typeof CustomDate,
-    Error: typeof CustomError,
-    Promise: typeof CustomPromise,
-
-    Config: typeof Config,
-    Got: typeof Got,
-
-    Cache: InstanceType<typeof CacheSingleton>,
-    Metrics: InstanceType<typeof MetricsSingleton>,
-    Query: InstanceType<typeof QuerySingleton>,
-    Utils: InstanceType<typeof UtilsSingleton>,
-};
-
-// declare type ModuleName = keyof GlobalSbObject;
-declare type ModuleFilePath = "classes/afk"
-    | "classes/config"
-    | "classes/got"
-    | "objects/date"
-    | "objects/error"
-    | "objects/errors"
-    | "objects/promise"
-    | "singletons/cache"
-    | "singletons/metrics"
-    | "singletons/query"
-    | "singletons/twitter"
-    | "singletons/utils"
-
-declare type OptionsObject = {
-    blacklist?: ModuleFilePath[];
-    whitelist?: ModuleFilePath[];
-    skipData?: ModuleFilePath[];
-};
-
-export default function initialize (options?: OptionsObject): Promise<GlobalSbObject>;
+export type * as Cache from "./singletons/cache.d.ts";
+export type * as Metrics from "./singletons/metrics.d.ts";
+export type * as Query from "./singletons/query/index.d.ts";
+export type * as Utils from "./singletons/utils.d.ts";

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -5,7 +5,7 @@ export type * as Promise from "./objects/promise.d.ts";
 
 // classes
 export type * as Config from "./classes/config.d.ts";
-export type * as GotProxy from "./classes/got-proxy.d.ts";
+export type * as Got from "./classes/got-proxy.d.ts";
 
 // singletons
 export type * as Cache from "./singletons/cache.d.ts";

--- a/@types/objects/date.d.ts
+++ b/@types/objects/date.d.ts
@@ -13,7 +13,7 @@ export declare type TimeUnit = "h" | "m" | "s" | "ms";
  * Extension of the native JavaScript Date class, with several additions to its API.
  * Note: the addition of `addX` methods, format and setters/getters for time units.
  */
-export declare class CustomDate extends Date {
+export declare class SupiDate extends Date {
 	static months: Month[];
 
 	/**
@@ -24,7 +24,7 @@ export declare class CustomDate extends Date {
 	/**
 	 * Compares two instances for their equality.
 	 */
-	static equals (from: CustomDate, to: CustomDate): boolean;
+	static equals (from: SupiDate, to: SupiDate): boolean;
 
 	/**
 	 * Pads a number with specified number of zeroes.
@@ -98,25 +98,25 @@ export declare class CustomDate extends Date {
 	 * Sets the current timezone offset to the provided value.
 	 * The offset provided is in minutes
 	 */
-	setTimezoneOffset (offset: number): CustomDate;
+	setTimezoneOffset (offset: number): SupiDate;
 
 	/**
 	 * Sets the provided time units to zero.
 	 */
-	discardTimeUnits (...units: TimeUnit[]): CustomDate;
+	discardTimeUnits (...units: TimeUnit[]): SupiDate;
 
 	/**
-	 * Clones the current CustomDate. The new object is independent of the old one.
+	 * Clones the current SupiDate. The new object is independent of the old one.
 	 */
-	clone (): CustomDate;
+	clone (): SupiDate;
 
-	addYears (y: number): CustomDate;
-	addMonths (m: number): CustomDate;
-	addDays (d: number): CustomDate;
-	addHours (h: number): CustomDate;
-	addMinutes (m: number): CustomDate;
-	addSeconds (s: number): CustomDate;
-	addMilliseconds (ms: number): CustomDate;
+	addYears (y: number): SupiDate;
+	addMonths (m: number): SupiDate;
+	addDays (d: number): SupiDate;
+	addHours (h: number): SupiDate;
+	addMinutes (m: number): SupiDate;
+	addSeconds (s: number): SupiDate;
+	addMilliseconds (ms: number): SupiDate;
 
 	get dayOfTheWeek (): DayOfTheWeek;
 	get year (): number;

--- a/@types/objects/error.d.ts
+++ b/@types/objects/error.d.ts
@@ -1,9 +1,9 @@
-import { JSONifiable, SimpleGenericData } from "../globals";
+import type { JSONifiable, SimpleGenericData } from "../globals.d.ts";
 
 /**
  * Custom error object. Receives an arguments object to provide more detailed error context.
  */
-export declare class CustomError extends Error {
+export declare class SupiError extends Error {
 	readonly #args: SimpleGenericData;
 	readonly #timestamp: number;
 	readonly #messageDescriptor: PropertyDescriptor;
@@ -47,7 +47,7 @@ export declare class CustomError extends Error {
 	static get GenericRequest (): GenericRequestError;
 }
 
-export declare class GenericRequestError extends CustomError {
+export declare class GenericRequestError extends SupiError {
 	constructor (obj?: {
 		message: string;
 		statusCode: number | null;

--- a/@types/objects/promise.d.ts
+++ b/@types/objects/promise.d.ts
@@ -7,12 +7,12 @@ declare type Handler<T> = (
  * Custom Promise wrapper.
  * Allows resolution/rejection from outside the Promise's context.
  */
-export declare class CustomPromise<T> extends Promise<T> {
+export declare class SupiPromise<T> extends Promise<T> {
 	#resolve;
 	#reject;
 
 	constructor (handler: Handler<T>);
 
-	resolve (value: any): CustomPromise<T>;
-	reject (value: any): CustomPromise<T>;
+	resolve (value: any): SupiPromise<T>;
+	reject (value: any): SupiPromise<T>;
 }

--- a/@types/singletons/cache.d.ts
+++ b/@types/singletons/cache.d.ts
@@ -1,5 +1,5 @@
 import { Redis, RedisOptions } from "ioredis";
-import { JSONifiable, Port, Stringifiable, URL } from "../globals";
+import type { JSONifiable, Port, Stringifiable, URL } from "../globals.d.ts";
 
 declare type Ok = "OK";
 export declare type Configuration = Port | URL | RedisOptions;

--- a/@types/singletons/cache.d.ts
+++ b/@types/singletons/cache.d.ts
@@ -31,7 +31,7 @@ export declare type KeysPrefixOptions = Partial<KeyOptions> & {
 /**
  * Redis caching module with methods to ease up item lookup.
  */
-export declare class CacheSingleton {
+export declare class Cache {
     static resolveKey (value: Key): string;
     static resolvePrefix (mainKey: string, keys: PrefixObject): string;
 
@@ -48,8 +48,8 @@ export declare class CacheSingleton {
     set (data: SetOptions): Promise<Ok | null>; // inferred from Redis["set"] for the non-callback overload
     get (keyIdentifier: Key): Promise<Value>;
     delete (keyIdentifier: Key): Promise<number>; // inferred from Redis["del"] for the non-callback overload;
-    setByPrefix (prefix: Prefix, value: Value, options?: PrefixOptions): ReturnType<CacheSingleton["set"]>;
-    getByPrefix (prefix: Prefix, options?: PrefixOptions): ReturnType<CacheSingleton["get"]>;
+    setByPrefix (prefix: Prefix, value: Value, options?: PrefixOptions): ReturnType<Cache["set"]>;
+    getByPrefix (prefix: Prefix, options?: PrefixOptions): ReturnType<Cache["get"]>;
     getKeysByPrefix (prefix: Prefix, options: KeysPrefixOptions): Promise<string[]>;
     getKeyValuesByPrefix (prefix: Prefix, options: KeysPrefixOptions): Promise<Value[]>;
     destroy (): void;

--- a/@types/singletons/cache.d.ts
+++ b/@types/singletons/cache.d.ts
@@ -28,6 +28,9 @@ export declare type KeysPrefixOptions = Partial<KeyOptions> & {
     count?: number;
 };
 
+/**
+ * Redis caching module with methods to ease up item lookup.
+ */
 export declare class CacheSingleton {
     static resolveKey (value: Key): string;
     static resolvePrefix (mainKey: string, keys: PrefixObject): string;
@@ -35,11 +38,13 @@ export declare class CacheSingleton {
     #active: boolean;
     #server: Redis;
     #version: Version;
+    #configuration: Configuration;
 
-    constructor ();
+    constructor (configuration: Configuration);
 
-    connect (configuration: Configuration): void;
+    connect (): Promise<void>;
     disconnect (): void;
+
     set (data: SetOptions): Promise<Ok | null>; // inferred from Redis["set"] for the non-callback overload
     get (keyIdentifier: Key): Promise<Value>;
     delete (keyIdentifier: Key): Promise<number>; // inferred from Redis["del"] for the non-callback overload;

--- a/@types/singletons/metrics.d.ts
+++ b/@types/singletons/metrics.d.ts
@@ -15,7 +15,7 @@ import {
 
 export { Counter, Gauge, Histogram, MetricType, Registry } from "prom-client";
 
-export declare class MetricsSingleton {
+export declare class Metrics {
 	constructor ();
 
 	register <T extends string>(type: MetricType, options: MetricConfiguration<T>): Metric<T>;

--- a/@types/singletons/metrics.d.ts
+++ b/@types/singletons/metrics.d.ts
@@ -28,5 +28,4 @@ export declare class MetricsSingleton {
 	destroy (): void;
 
 	get registry (): Registry;
-	get modulePath (): "metrics";
 }

--- a/@types/singletons/query/batch.d.ts
+++ b/@types/singletons/query/batch.d.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     ColumnDefinition,
     Database,
     Field,
@@ -6,7 +6,7 @@ import {
     GenericQueryBuilderOptions,
     QuerySingleton as Query,
     Table
-} from "./index";
+} from "./index.d.ts";
 import { PoolConnection } from "mariadb";
 
 declare type ConstructorOptions = GenericQueryBuilderOptions & {

--- a/@types/singletons/query/index.d.ts
+++ b/@types/singletons/query/index.d.ts
@@ -104,7 +104,7 @@ export declare type ConstructorOptions = PathConstructorOptions | HostConstructo
  * - {@link RecordUpdater}: UPDATEs specified columns with values, with specified condition(s)
  * - {@link Row}: Single table row, select/insert/update/delete
  */
-export declare class QuerySingleton {
+export declare class Query {
     static get flagMask (): Flags;
     static get sqlKeywords (): string[];
 
@@ -124,12 +124,12 @@ export declare class QuerySingleton {
     /**
      * Alias of {@link Query.raw}
      */
-    send (...args: string[]): ReturnType<QuerySingleton["raw"]>;
+    send (...args: string[]): ReturnType<Query["raw"]>;
 
     /**
      * Allows a transaction-based query, or a regular one if none is provided.
      */
-    transactionQuery (sqlString: string, transaction: PoolConnection | null): ReturnType<QuerySingleton["raw"]>;
+    transactionQuery (sqlString: string, transaction: PoolConnection | null): ReturnType<Query["raw"]>;
 
     /**
      * Prepares a transaction for next use.

--- a/@types/singletons/query/index.d.ts
+++ b/@types/singletons/query/index.d.ts
@@ -1,11 +1,12 @@
-import { Batch, ConstructorOptions as BatchOptions } from "./batch";
-import { Row } from "./row";
-import { RecordDeleter } from "./record-deleter";
-import { Recordset } from "./recordset";
-import { RecordUpdater } from "./record-updater";
-import { CustomDate as Date } from "../../objects/date";
+import type { Batch, ConstructorOptions as BatchOptions } from "./batch.d.ts";
+import type { Row } from "./row.d.ts";
+import type { RecordDeleter } from "./record-deleter.d.ts";
+import type { Recordset } from "./recordset.d.ts";
+import type { RecordUpdater } from "./record-updater.d.ts";
+import type { SupiDate } from "../../objects/date.d.ts";
+import type { SimpleGenericData } from "../../globals.d.ts";
+
 import { Flags, Pool, PoolConnection, Types as ColumnType } from "mariadb";
-import { SimpleGenericData } from "../../globals";
 
 export {
     Batch,
@@ -70,7 +71,7 @@ export declare type Database = TableDefinition["database"];
 export declare type Field = ColumnDefinition["name"];
 export declare type Table = TableDefinition["name"];
 export declare type FormatSymbol = "b" | "d" | "dt" | "n" | "s" | "t" | "s+" | "n+" | "like" | "like*" | "*like" | "*like*";
-export declare type FormatValue = number | string | boolean | Date | SimpleGenericData | bigint | string[] | null;
+export declare type FormatValue = number | string | boolean | SupiDate | SimpleGenericData | bigint | string[] | null;
 export declare type WhereHavingObject = {
     condition?: boolean;
     raw?: string;

--- a/@types/singletons/query/index.d.ts
+++ b/@types/singletons/query/index.d.ts
@@ -79,6 +79,21 @@ export declare type GenericQueryBuilderOptions = {
     transaction?: PoolConnection
 };
 
+declare type CommonConstructorOptions = {
+    user: string;
+    password: string;
+    connectionLimit?: number;
+};
+declare type PathConstructorOptions = CommonConstructorOptions & {
+    path: string;
+};
+declare type HostConstructorOptions = CommonConstructorOptions & {
+    host: string;
+    port?: number;
+};
+
+export declare type ConstructorOptions = PathConstructorOptions | HostConstructorOptions;
+
 /**
  * Query represents every possible access to the database.
  *
@@ -98,7 +113,7 @@ export declare class QuerySingleton {
     private tableDefinitions: TableDefinition[];
     private pool: Pool | null;
 
-    constructor ();
+    constructor (options: ConstructorOptions);
 
     /**
      * Executes a raw SQL query.
@@ -200,5 +215,4 @@ export declare class QuerySingleton {
     disableLogThreshold (): void;
 
     destroy (): void;
-    get modulePath (): "query";
 }

--- a/@types/singletons/query/record-deleter.d.ts
+++ b/@types/singletons/query/record-deleter.d.ts
@@ -1,10 +1,10 @@
-import {
+import type {
     Database,
     GenericQueryBuilderOptions,
     QuerySingleton as Query,
     Table,
     WhereHavingObject
-} from "./index";
+} from "./index.d.ts";
 
 import { PoolConnection } from "mariadb";
 

--- a/@types/singletons/query/record-updater.d.ts
+++ b/@types/singletons/query/record-updater.d.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     Database,
     Field,
     FormatValue,
@@ -6,7 +6,7 @@ import {
     QuerySingleton as Query,
     Table,
     WhereHavingObject
-} from "./index";
+} from "./index.d.ts";
 
 import { PoolConnection } from "mariadb";
 

--- a/@types/singletons/query/recordset.d.ts
+++ b/@types/singletons/query/recordset.d.ts
@@ -1,11 +1,11 @@
-import {
+import type {
     ColumnDefinition,
     Database,
     FormatValue,
     GenericQueryBuilderOptions,
     QuerySingleton as Query,
     Table
-} from "./index";
+} from "./index.d.ts";
 import { PoolConnection } from "mariadb";
 
 declare type Field = ColumnDefinition["name"];

--- a/@types/singletons/query/row.d.ts
+++ b/@types/singletons/query/row.d.ts
@@ -1,10 +1,10 @@
-import { ColumnDefinition, GenericQueryBuilderOptions, QuerySingleton as Query, TableDefinition } from "./index";
-import { CustomDate } from "../../objects/date";
+import type { ColumnDefinition, GenericQueryBuilderOptions, QuerySingleton as Query, TableDefinition } from "./index.d.ts";
+import type { SupiDate } from "../../objects/date.d.ts";
 import { PoolConnection, TypeCastResult, UpsertResult } from "mariadb";
 
 declare const unsetSymbol: symbol;
 
-declare type PrimaryKey = string | number | bigint | CustomDate | Buffer;
+declare type PrimaryKey = string | number | bigint | SupiDate | Buffer;
 declare type CompoundPrimaryKey = {
     [P: string]: PrimaryKey;
 };
@@ -23,7 +23,7 @@ declare type ErrorInfo = {
     loaded: boolean;
 };
 
-declare type RowValue = string | boolean | number | null | CustomDate | Date | { [p: string]: RowValue } | RowValue[];
+declare type RowValue = string | boolean | number | null | SupiDate | Date | { [p: string]: RowValue } | RowValue[];
 declare type RowValueWrapper = Record<string, RowValue>;
 
 // @todo possibly declare a row of a specific (object) type imported from elsewhere - via type params?

--- a/@types/singletons/utils.d.ts
+++ b/@types/singletons/utils.d.ts
@@ -1,5 +1,5 @@
-import { Message, Stringifiable, URL } from "../globals";
-import { CustomDate } from "../objects/date";
+import type { Message, Stringifiable, URL } from "../globals.d.ts";
+import type { SupiDate } from "../objects/date.d.ts";
 
 import { Url as NativeURLObject } from "url";
 
@@ -75,7 +75,7 @@ declare namespace GeoData {
 }
 
 declare type TimeOptions = {
-    date?: number | Date | CustomDate;
+    date?: number | Date | SupiDate;
     coordinates: GeoData.Location;
     key: string;
 };
@@ -129,7 +129,7 @@ export declare namespace YT {
     };
     type PlaylistVideo = Video & {
         channelTitle: string;
-        published: CustomDate;
+        published: SupiDate;
         position: number;
     };
     type PlaylistResult = {
@@ -202,7 +202,7 @@ export declare class Utils {
     constructor ();
 
     capitalize (string: string): string;
-    timeDelta (target: CustomDate | Date | number, skipAffixes?: boolean, respectLeapYears?: boolean, deltaTo?: CustomDate): string;
+    timeDelta (target: SupiDate | Date | number, skipAffixes?: boolean, respectLeapYears?: boolean, deltaTo?: SupiDate): string;
     toDictionary (message: Message, orderBy: "asc" | "desc"): Map<string, number>;
     round (number: number, places?: number, options?: RoundOptions): number;
     escapeHTML (string: string): string;

--- a/@types/singletons/utils.d.ts
+++ b/@types/singletons/utils.d.ts
@@ -5,18 +5,11 @@ import { Url as NativeURLObject } from "url";
 
 import { CheerioAPI } from "cheerio";
 import { ParsedResult, ParsingOption } from "chrono-node";
-import { TrackLinkParser } from "track-link-parser";
-import { Parser as LanguageParser } from "language-iso-codes";
 import { Output as RSSOutput } from "rss-parser";
 import { Random } from "random-js";
 import { parse as DurationParseFunction } from "duration-parser";
 // import * as FFProbe from "ffprobe";
 import { transliterate as TransliterateFunction } from "transliteration";
-
-declare type Modules = {
-    linkParser: TrackLinkParser;
-    languageISO: LanguageParser;
-};
 
 declare interface MathProperties {
     [P: string]: keyof Math
@@ -178,7 +171,7 @@ declare type UploadResult = {
     link: string | null;
 };
 
-export declare class UtilsSingleton {
+export declare class Utils {
     static readonly timeUnits: {
         y: { d: 365, h: 8760, m: 525600, s: 31536000, ms: 31536000.0e3 };
         d: { h: 24, m: 1440, s: 86400, ms: 86400.0e3 };
@@ -264,8 +257,6 @@ export declare class UtilsSingleton {
     escapeRegExp (string: string): string;
     parseRegExp (string: string): RegExp | null;
     replaceLinks (string: string, replacement?: string): string;
-
-    get modules (): Modules;
 
     destroy (): void;
     get modulePath (): "cache";

--- a/classes/config.js
+++ b/classes/config.js
@@ -3,7 +3,7 @@ import SupiError from "../objects/error.js";
 
 const VALID_BOOLEAN_LIKE_VALUES = ["0", "1", "true", "false"];
 
-module.exports = class Config {
+export default class Config {
 	#Name;
 	#Value;
 	#Type;

--- a/classes/config.js
+++ b/classes/config.js
@@ -1,5 +1,5 @@
-import SupiDate from "../objects/date";
-import SupiError from "../objects/error";
+import SupiDate from "../objects/date.js";
+import SupiError from "../objects/error.js";
 
 const VALID_BOOLEAN_LIKE_VALUES = ["0", "1", "true", "false"];
 

--- a/classes/config.js
+++ b/classes/config.js
@@ -7,9 +7,7 @@ module.exports = class Config {
 	#Name;
 	#Value;
 	#Type;
-	#Secret;
 	#Editable;
-
 	#initialized = false;
 
 	static data = new Map();
@@ -18,7 +16,6 @@ module.exports = class Config {
 	constructor (data) {
 		this.#Name = data.Name;
 		this.#Type = data.Type;
-		this.#Secret = Boolean(data.Secret);
 		this.#Editable = Boolean(data.Editable);
 
 		this.value = data.Value;

--- a/classes/config.js
+++ b/classes/config.js
@@ -11,7 +11,6 @@ module.exports = class Config {
 	#initialized = false;
 
 	static data = new Map();
-	static uniqueIdentifier = "Name";
 
 	constructor (data) {
 		this.#Name = data.Name;

--- a/classes/got-proxy.js
+++ b/classes/got-proxy.js
@@ -212,7 +212,7 @@ class StaticGot {
 	static get FormData () { return FormData; }
 }
 
-export default new Proxy(StaticGot, {
+const GotProxy = new Proxy(StaticGot, {
 	apply: function (target, thisArg, args) {
 		const options = args.find(i => typeof i === "object" && i?.constructor?.name === "Object");
 		if (options && typeof options.url === "string" && !options.skipURLSanitization) {
@@ -237,3 +237,5 @@ export default new Proxy(StaticGot, {
 		return target[property] ?? gotModule[property] ?? gotModule.got[property];
 	}
 });
+
+export default GotProxy;

--- a/classes/got-proxy.js
+++ b/classes/got-proxy.js
@@ -17,9 +17,6 @@ const sanitize = (string) => string
 	.replaceAll(/%2E%2E[/\\]?/g, "");
 
 class StaticGot {
-	static importable = true;
-	static uniqueIdentifier = nameSymbol;
-
 	static get (identifier) {
 		if (identifier instanceof StaticGot) {
 			return identifier;
@@ -206,8 +203,6 @@ class StaticGot {
 	static isRequestError (error) {
 		return gotRequestErrors.some(GotError => error instanceof GotError);
 	}
-
-	static get specificName () { return "Got"; }
 
 	static get FormData () { return FormData; }
 }

--- a/classes/got.js
+++ b/classes/got.js
@@ -1,251 +1,239 @@
-/**
- * Represents a single `Got` instance with its own default options
- */
-module.exports = (function () {
-	const FormData = require("form-data");
-	const nameSymbol = Symbol.for("name");
+import FormData from "form-data";
+import * as gotModule from "got";
 
-	let gotModule;
-	let gotRequestErrors;
+const nameSymbol = Symbol.for("name");
+const gotRequestErrors = [
+	gotModule.CancelError,
+	gotModule.HTTPError,
+	gotModule.RequestError,
+	gotModule.TimeoutError
+];
 
-	// Replace out all occurrences of the "up one level" string - "../"
-	// Also if they are followed with another one, like so: "../.."
-	// Same thing applies for "%2E" - the escaped version of "."; and for backslash used instead of forward slash.
-	const sanitize = (string) => string
-		.replaceAll(/\.\.[/\\]?/g, "")
-		.replaceAll(/%2E%2E[/\\]?/g, "");
+// Replace out all occurrences of the "up one level" string - "../"
+// Also if they are followed with another one, like so: "../.."
+// Same thing applies for "%2E" - the escaped version of "."; and for backslash used instead of forward slash.
+const sanitize = (string) => string
+	.replaceAll(/\.\.[/\\]?/g, "")
+	.replaceAll(/%2E%2E[/\\]?/g, "");
 
-	class StaticGot {
-		static importable = true;
-		static uniqueIdentifier = nameSymbol;
+class StaticGot {
+	static importable = true;
+	static uniqueIdentifier = nameSymbol;
 
-		static async initialize () {
-			gotModule ??= await import("got");
-			gotRequestErrors ??= [
-				gotModule.CancelError,
-				gotModule.HTTPError,
-				gotModule.RequestError,
-				gotModule.TimeoutError
-			];
-
-			return this;
+	static get (identifier) {
+		if (identifier instanceof StaticGot) {
+			return identifier;
 		}
-
-		static get (identifier) {
-			if (identifier instanceof StaticGot) {
-				return identifier;
-			}
-			else if (typeof identifier === "string") {
-				return StaticGot.data.find(i => i[nameSymbol] === identifier) ?? null;
-			}
-			else {
-				throw new sb.Error({
-					message: "Invalid user identifier type",
-					args: { id: identifier, type: typeof identifier }
-				});
-			}
+		else if (typeof identifier === "string") {
+			return StaticGot.data.find(i => i[nameSymbol] === identifier) ?? null;
 		}
-
-		static async importData (definitions) {
-			if (!Array.isArray(definitions)) {
-				throw new sb.Error({
-					message: "Definitions must be provided as an array"
-				});
-			}
-
-			const instanceParents = new Set(definitions.map(i => i.parent));
-			const availableParents = new Set([null, ...definitions.map(i => i.name)]);
-			for (const instanceParent of instanceParents) {
-				if (!availableParents.has(instanceParent)) {
-					throw new sb.Error({
-						message: "Instance parent is not defined",
-						args: {
-							requested: instanceParent,
-							availableParents: [...availableParents]
-						}
-					});
-				}
-			}
-
-			let count = 0;
-			const result = [];
-			const loadedParents = new Set();
-			const loadedDefinitions = new Set();
-
-			while (result.length < definitions.length) {
-				const index = count % definitions.length;
-				const definition = definitions[index % definitions.length];
-				if (!loadedDefinitions.has(definition) && (definition.parent === null || loadedParents.has(definition.parent))) {
-					const instance = StaticGot.#add(definition, result);
-					result.push(instance);
-					loadedParents.add(instance[nameSymbol]);
-					loadedDefinitions.add(definition);
-				}
-
-				count++;
-			}
-
-			StaticGot.data = result;
+		else {
+			throw new sb.Error({
+				message: "Invalid user identifier type",
+				args: { id: identifier, type: typeof identifier }
+			});
 		}
-
-		static async importSpecific (...definitions) {
-			for (const definition of definitions) {
-				const oldInstanceIndex = StaticGot.data.findIndex(i => i[nameSymbol] === definition.name);
-				if (oldInstanceIndex !== -1) {
-					StaticGot.data.splice(oldInstanceIndex, 1);
-				}
-
-				const newInstance = StaticGot.#add(definition, StaticGot.data);
-				StaticGot.data.push(newInstance);
-			}
-		}
-
-		static #add (definition, parentDefinitions) {
-			let initError;
-			let options = {};
-			if (definition.optionsType === "object") {
-				options = definition.options;
-			}
-			else if (definition.optionsType === "function") {
-				try {
-					options = definition.options();
-				}
-				catch (e) {
-					console.warn(`Got instance ${definition.name} init error - skipped`, e);
-					initError = e;
-				}
-			}
-
-			let instance;
-			if (initError) {
-				instance = () => {
-					throw new sb.Error({
-						message: "Instance is not available due to initialization error",
-						args: { definition },
-						cause: initError
-					});
-				};
-			}
-			else if (definition.parent) {
-				const parent = parentDefinitions.find(i => i[nameSymbol] === definition.parent);
-				if (!parent) {
-					throw new sb.Error({
-						message: "Requested parent instance does not exist",
-						args: {
-							requested: definition.parent,
-							existing: parentDefinitions.map(i => i[nameSymbol])
-						}
-					});
-				}
-
-				instance = parent.extend(options);
-			}
-			else {
-				instance = gotModule.got.extend(options);
-			}
-
-			instance[nameSymbol] = definition.name;
-
-			return instance;
-		}
-
-		static gql (gqlOptions = {}) {
-			if (!gqlOptions.query) {
-				throw new sb.Error({
-					message: "Missing parameter query for GQL request",
-					args: { gqlOptions }
-				});
-			}
-
-			const options = {
-				method: "POST",
-				responseType: "json",
-				json: {
-					query: gqlOptions.query
-				}
-			};
-
-			delete gqlOptions.query;
-
-			if (gqlOptions.token) {
-				options.headers = (gqlOptions.headers) ? { ...gqlOptions.headers } : {};
-				options.headers.Authorization = `Bearer ${gqlOptions.token}`;
-
-				delete gqlOptions.headers;
-				delete gqlOptions.token;
-			}
-
-			if (gqlOptions.variables) {
-				options.json.variables = gqlOptions.variables;
-
-				delete gqlOptions.variables;
-			}
-
-			return gotModule.got({ ...gqlOptions, ...options });
-		}
-
-		static sanitize (strings, ...values) {
-			const result = [];
-			for (let i = 0; i < strings.length; i++) {
-				result.push(strings[i]);
-
-				if (typeof values[i] === "string") {
-					result.push(sanitize(values[i]));
-				}
-			}
-
-			return result.join("").trim();
-		}
-
-		static extend (extendOptions) {
-			const extension = gotModule.got.extend(extendOptions);
-			return (urlOrOptions, restOptions) => {
-				if (typeof restOptions?.url === "string") {
-					restOptions.url = sanitize(restOptions.url);
-				}
-				else if (typeof urlOrOptions?.url === "string") {
-					urlOrOptions.url = sanitize(urlOrOptions.url);
-				}
-				else if (typeof urlOrOptions === "string") {
-					urlOrOptions = sanitize(urlOrOptions);
-				}
-
-				return extension(urlOrOptions, restOptions);
-			};
-		}
-
-		static isRequestError (error) {
-			return gotRequestErrors.some(GotError => error instanceof GotError);
-		}
-
-		static get specificName () { return "Got"; }
-
-		static get FormData () { return FormData; }
 	}
 
-	return new Proxy(StaticGot, {
-		apply: function (target, thisArg, args) {
-			const options = args.find(i => typeof i === "object" && i?.constructor?.name === "Object");
-			if (options && typeof options.url === "string" && !options.skipURLSanitization) {
-				options.url = sanitize(options.url);
-			}
-
-			if (typeof args[1] === "string") {
-				args[1] = sanitize(args[1]);
-			}
-
-			if (typeof args[0] === "string") {
-				const instance = StaticGot.get(args[0]);
-				if (instance) {
-					return instance(...args.slice(1));
-				}
-			}
-
-			return gotModule.got(...args);
-		},
-
-		get: function (target, property) {
-			return target[property] ?? gotModule[property] ?? gotModule.got[property];
+	static async importData (definitions) {
+		if (!Array.isArray(definitions)) {
+			throw new sb.Error({
+				message: "Definitions must be provided as an array"
+			});
 		}
-	});
-})();
+
+		const instanceParents = new Set(definitions.map(i => i.parent));
+		const availableParents = new Set([null, ...definitions.map(i => i.name)]);
+		for (const instanceParent of instanceParents) {
+			if (!availableParents.has(instanceParent)) {
+				throw new sb.Error({
+					message: "Instance parent is not defined",
+					args: {
+						requested: instanceParent,
+						availableParents: [...availableParents]
+					}
+				});
+			}
+		}
+
+		let count = 0;
+		const result = [];
+		const loadedParents = new Set();
+		const loadedDefinitions = new Set();
+
+		while (result.length < definitions.length) {
+			const index = count % definitions.length;
+			const definition = definitions[index % definitions.length];
+			if (!loadedDefinitions.has(definition) && (definition.parent === null || loadedParents.has(definition.parent))) {
+				const instance = StaticGot.#add(definition, result);
+				result.push(instance);
+				loadedParents.add(instance[nameSymbol]);
+				loadedDefinitions.add(definition);
+			}
+
+			count++;
+		}
+
+		StaticGot.data = result;
+	}
+
+	static async importSpecific (...definitions) {
+		for (const definition of definitions) {
+			const oldInstanceIndex = StaticGot.data.findIndex(i => i[nameSymbol] === definition.name);
+			if (oldInstanceIndex !== -1) {
+				StaticGot.data.splice(oldInstanceIndex, 1);
+			}
+
+			const newInstance = StaticGot.#add(definition, StaticGot.data);
+			StaticGot.data.push(newInstance);
+		}
+	}
+
+	static #add (definition, parentDefinitions) {
+		let initError;
+		let options = {};
+		if (definition.optionsType === "object") {
+			options = definition.options;
+		}
+		else if (definition.optionsType === "function") {
+			try {
+				options = definition.options();
+			}
+			catch (e) {
+				console.warn(`Got instance ${definition.name} init error - skipped`, e);
+				initError = e;
+			}
+		}
+
+		let instance;
+		if (initError) {
+			instance = () => {
+				throw new sb.Error({
+					message: "Instance is not available due to initialization error",
+					args: { definition },
+					cause: initError
+				});
+			};
+		}
+		else if (definition.parent) {
+			const parent = parentDefinitions.find(i => i[nameSymbol] === definition.parent);
+			if (!parent) {
+				throw new sb.Error({
+					message: "Requested parent instance does not exist",
+					args: {
+						requested: definition.parent,
+						existing: parentDefinitions.map(i => i[nameSymbol])
+					}
+				});
+			}
+
+			instance = parent.extend(options);
+		}
+		else {
+			instance = gotModule.got.extend(options);
+		}
+
+		instance[nameSymbol] = definition.name;
+
+		return instance;
+	}
+
+	static gql (gqlOptions = {}) {
+		if (!gqlOptions.query) {
+			throw new sb.Error({
+				message: "Missing parameter query for GQL request",
+				args: { gqlOptions }
+			});
+		}
+
+		const options = {
+			method: "POST",
+			responseType: "json",
+			json: {
+				query: gqlOptions.query
+			}
+		};
+
+		delete gqlOptions.query;
+
+		if (gqlOptions.token) {
+			options.headers = (gqlOptions.headers) ? { ...gqlOptions.headers } : {};
+			options.headers.Authorization = `Bearer ${gqlOptions.token}`;
+
+			delete gqlOptions.headers;
+			delete gqlOptions.token;
+		}
+
+		if (gqlOptions.variables) {
+			options.json.variables = gqlOptions.variables;
+
+			delete gqlOptions.variables;
+		}
+
+		return gotModule.got({ ...gqlOptions, ...options });
+	}
+
+	static sanitize (strings, ...values) {
+		const result = [];
+		for (let i = 0; i < strings.length; i++) {
+			result.push(strings[i]);
+
+			if (typeof values[i] === "string") {
+				result.push(sanitize(values[i]));
+			}
+		}
+
+		return result.join("").trim();
+	}
+
+	static extend (extendOptions) {
+		const extension = gotModule.got.extend(extendOptions);
+		return (urlOrOptions, restOptions) => {
+			if (typeof restOptions?.url === "string") {
+				restOptions.url = sanitize(restOptions.url);
+			}
+			else if (typeof urlOrOptions?.url === "string") {
+				urlOrOptions.url = sanitize(urlOrOptions.url);
+			}
+			else if (typeof urlOrOptions === "string") {
+				urlOrOptions = sanitize(urlOrOptions);
+			}
+
+			return extension(urlOrOptions, restOptions);
+		};
+	}
+
+	static isRequestError (error) {
+		return gotRequestErrors.some(GotError => error instanceof GotError);
+	}
+
+	static get specificName () { return "Got"; }
+
+	static get FormData () { return FormData; }
+}
+
+export default new Proxy(StaticGot, {
+	apply: function (target, thisArg, args) {
+		const options = args.find(i => typeof i === "object" && i?.constructor?.name === "Object");
+		if (options && typeof options.url === "string" && !options.skipURLSanitization) {
+			options.url = sanitize(options.url);
+		}
+
+		if (typeof args[1] === "string") {
+			args[1] = sanitize(args[1]);
+		}
+
+		if (typeof args[0] === "string") {
+			const instance = StaticGot.get(args[0]);
+			if (instance) {
+				return instance(...args.slice(1));
+			}
+		}
+
+		return gotModule.got(...args);
+	},
+
+	get: function (target, property) {
+		return target[property] ?? gotModule[property] ?? gotModule.got[property];
+	}
+});

--- a/index.js
+++ b/index.js
@@ -2,13 +2,13 @@ import Date from "./objects/date.js";
 import Error from "./objects/error.js";
 import Promise from "./objects/promise.js";
 
+import Config from "./classes/config.js";
+import Got from "./classes/got-proxy.js";
+
 import Query from "./singletons/query/index.js";
 import Cache from "./singletons/cache.js";
 import Metrics from "./singletons/metrics.js";
 import Utils from "./singletons/utils.js";
-
-import Config from "./classes/config.js";
-import Got from "./classes/got-proxy.js";
 
 export {
 	Date,

--- a/index.js
+++ b/index.js
@@ -1,11 +1,25 @@
-export * as Date from "./objects/date.js";
-export * as Error from "./objects/error.js";
-export * as Promise from "./objects/promise.js";
+import Date from "./objects/date.js";
+import Error from "./objects/error.js";
+import Promise from "./objects/promise.js";
 
-export * as Query from "./singletons/query/index.js";
-export * as Cache from "./singletons/cache.js";
-export * as Metrics from "./singletons/metrics.js";
-export * as Utils from "./singletons/utils.js";
+import Query from "./singletons/query/index.js";
+import Cache from "./singletons/cache.js";
+import Metrics from "./singletons/metrics.js";
+import Utils from "./singletons/utils.js";
 
-export * as Config from "./classes/config.js";
-export * as Got from "./classes/got-proxy.js";
+import Config from "./classes/config.js";
+import Got from "./classes/got-proxy.js";
+
+export {
+	Date,
+	Error,
+	Promise,
+
+	Config,
+	Got,
+
+	Query,
+	Cache,
+	Metrics,
+	Utils
+};

--- a/index.js
+++ b/index.js
@@ -1,71 +1,11 @@
-module.exports = (async function (options = {}) {
-	/**
-	 * Global namespace wrapper.
-	 * @namespace
-	 * @type {GlobalSbObject}
-	 */
-	globalThis.sb = {};
+export * from "./objects/date";
+export * from "./objects/error";
+export * from "./objects/promise";
 
-	const files = [
-		"objects/date",
-		"objects/error",
-		"objects/promise",
+export * from "./singletons/query";
+export * from "./singletons/cache";
+export * from "./singletons/metrics";
+export * from "./singletons/utils";
 
-		"singletons/metrics",
-		"singletons/query",
-		"classes/config",
-
-		"singletons/utils",
-		"singletons/cache",
-		"classes/got"
-	];
-
-	const {
-		blacklist,
-		whitelist,
-		skipData = []
-	} = options;
-
-	console.groupCollapsed("module load performance");
-
-	for (const file of files) {
-		if (blacklist && blacklist.includes(file)) {
-			continue;
-		}
-		else if (whitelist && !whitelist.includes(file)) {
-			continue;
-		}
-
-		const start = process.hrtime.bigint();
-		const [type, moduleName] = file.split("/");
-
-		if (type === "objects") {
-			const component = require(`./${file}`);
-			const name = component.name.replace(/^Custom/, "");
-
-			sb[name] = component;
-		}
-		else if (type === "singletons") {
-			const Component = require(`./${file}`);
-			const name = Component.name.replace(/Singleton$/, "");
-
-			sb[name] = new Component();
-		}
-		else if (type === "classes") {
-			const component = require(`./${file}`);
-			if (skipData.includes(file)) {
-				sb[component.specificName ?? component.name] = component;
-			}
-			else {
-				sb[component.specificName ?? component.name] = await component.initialize();
-			}
-		}
-
-		const end = process.hrtime.bigint();
-		console.log(`${moduleName} loaded in ${Number(end - start) / 1e6} ms`);
-	}
-
-	console.groupEnd();
-
-	return globalThis.sb;
-});
+export * from "./classes/config";
+export * from "./classes/got";

--- a/index.js
+++ b/index.js
@@ -8,4 +8,4 @@ export * from "./singletons/metrics";
 export * from "./singletons/utils";
 
 export * from "./classes/config";
-export * from "./classes/got";
+export * from "./classes/got-proxy.js";

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-export * from "./objects/date";
-export * from "./objects/error";
-export * from "./objects/promise";
+export * from "./objects/date.js";
+export * from "./objects/error.js";
+export * from "./objects/promise.js";
 
-export * from "./singletons/query";
-export * from "./singletons/cache";
-export * from "./singletons/metrics";
-export * from "./singletons/utils";
+export * from "./singletons/query/index.js";
+export * from "./singletons/cache.js";
+export * from "./singletons/metrics.js";
+export * from "./singletons/utils.js";
 
-export * from "./classes/config";
+export * from "./classes/config.js";
 export * from "./classes/got-proxy.js";

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-export * from "./objects/date.js";
-export * from "./objects/error.js";
-export * from "./objects/promise.js";
+export * as Date from "./objects/date.js";
+export * as Error from "./objects/error.js";
+export * as Promise from "./objects/promise.js";
 
-export * from "./singletons/query/index.js";
-export * from "./singletons/cache.js";
-export * from "./singletons/metrics.js";
-export * from "./singletons/utils.js";
+export * as Query from "./singletons/query/index.js";
+export * as Cache from "./singletons/cache.js";
+export * as Metrics from "./singletons/metrics.js";
+export * as Utils from "./singletons/utils.js";
 
-export * from "./classes/config.js";
-export * from "./classes/got-proxy.js";
+export * as Config from "./classes/config.js";
+export * as Got from "./classes/got-proxy.js";

--- a/objects/date.js
+++ b/objects/date.js
@@ -318,4 +318,4 @@ export default class SupiDate extends Date {
 	set year (y) {
 		super.setFullYear(y);
 	}
-};
+}

--- a/objects/date.js
+++ b/objects/date.js
@@ -1,4 +1,4 @@
-module.exports = class CustomDate extends Date {
+export default class SupiDate extends Date {
 	static months = [
 		"January",
 		"February",
@@ -98,23 +98,23 @@ module.exports = class CustomDate extends Date {
 					value += this.dayOfTheWeek.slice(0, 3);
 					break;
 				case "F":
-					value += CustomDate.months[month - 1];
+					value += SupiDate.months[month - 1];
 					break;
 				case "M":
-					value += CustomDate.months[month - 1].slice(0, 3);
+					value += SupiDate.months[month - 1].slice(0, 3);
 					break;
 				case "S":
-					value += CustomDate.getDaySuffix(day);
+					value += SupiDate.getDaySuffix(day);
 					break;
 
 				case "d":
-					value += CustomDate.zf(day, 2);
+					value += SupiDate.zf(day, 2);
 					break;
 				case "j":
 					value += day;
 					break;
 				case "m":
-					value += CustomDate.zf(month, 2);
+					value += SupiDate.zf(month, 2);
 					break;
 				case "n":
 					value += month;
@@ -127,16 +127,16 @@ module.exports = class CustomDate extends Date {
 					value += hours;
 					break;
 				case "H":
-					value += CustomDate.zf(hours, 2);
+					value += SupiDate.zf(hours, 2);
 					break;
 				case "i":
-					value += CustomDate.zf(minutes, 2);
+					value += SupiDate.zf(minutes, 2);
 					break;
 				case "s":
-					value += CustomDate.zf(seconds, 2);
+					value += SupiDate.zf(seconds, 2);
 					break;
 				case "v":
-					value += CustomDate.zf(milli, 3);
+					value += SupiDate.zf(milli, 3);
 					break;
 
 				default:

--- a/objects/error.js
+++ b/objects/error.js
@@ -1,4 +1,4 @@
-class CustomError extends globalThis.Error {
+class SupiError extends globalThis.Error {
 	#args;
 	#timestamp;
 	#messageDescriptor;
@@ -64,7 +64,7 @@ class CustomError extends globalThis.Error {
 	}
 }
 
-class GenericRequestError extends CustomError {
+class GenericRequestError extends SupiError {
 	constructor (object = {}) {
 		super({
 			message: object.message,
@@ -83,4 +83,4 @@ class GenericRequestError extends CustomError {
 	}
 }
 
-module.exports = CustomError;
+export default SupiError;

--- a/objects/promise.js
+++ b/objects/promise.js
@@ -1,4 +1,4 @@
-module.exports = class CustomPromise extends global.Promise {
+export default class SupiPromise extends global.Promise {
 	#resolve = null;
 	#reject = null;
 

--- a/objects/promise.js
+++ b/objects/promise.js
@@ -28,4 +28,4 @@ export default class SupiPromise extends global.Promise {
 		this.#reject(value);
 		return this;
 	}
-};
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "supi-core",
-  "version": "2.2.0",
-  "description": "Supinic's projects' core modules, created in a global namespace",
+  "version": "3.0.0",
+  "description": "Supinic's projects' core modules",
   "main": "index.js",
+  "type": "module",
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",
     "chrono-node": "^2.7.0",

--- a/singletons/cache.js
+++ b/singletons/cache.js
@@ -322,4 +322,4 @@ export default class Cache {
 	get version () { return this.#version; }
 
 	get server () { return this.#server; }
-};
+}

--- a/singletons/cache.js
+++ b/singletons/cache.js
@@ -1,5 +1,5 @@
 import Redis from "ioredis";
-import SupiError from "../objects/error";
+import SupiError from "../objects/error.js";
 
 const GROUP_DELIMITER = String.fromCharCode(7);
 const ITEM_DELIMITER = String.fromCharCode(8);

--- a/singletons/cache.js
+++ b/singletons/cache.js
@@ -12,9 +12,9 @@ const isValidInteger = (input) => {
 	return Boolean(Number.isFinite(input) && Math.trunc(input) === input);
 };
 
-module.exports = class Cache {
+export default class Cache {
 	/** @type {Redis} */
-	#server = null;
+	#server;
 	#active = false;
 	#version = null;
 	#configuration;

--- a/singletons/cache.js
+++ b/singletons/cache.js
@@ -32,6 +32,7 @@ export default class Cache {
 		}
 
 		this.#configuration = configuration;
+		this.connect();
 	}
 
 	async connect () {
@@ -41,7 +42,7 @@ export default class Cache {
 			});
 		}
 		else if (this.#server) {
-			this.#server.connect();
+			await this.#server.connect();
 			this.#active = true;
 		}
 

--- a/singletons/metrics.js
+++ b/singletons/metrics.js
@@ -4,7 +4,7 @@ const availableMetricTypes = ["Counter", "Gauge", "Histogram", "Summary"];
 /**
  * Very simple module wrapper around the Prometheus client metrics
  */
-module.exports = class MetricsSingleton {
+export default class Metrics {
 	#registry;
 
 	constructor () {

--- a/singletons/query/batch.js
+++ b/singletons/query/batch.js
@@ -1,4 +1,4 @@
-import SupiError from "../../objects/error";
+import SupiError from "../../objects/error.js";
 
 /**
  * Represents the SQL INSERT statement for multiple rows.

--- a/singletons/query/batch.js
+++ b/singletons/query/batch.js
@@ -1,3 +1,5 @@
+import SupiError from "../../objects/error";
+
 /**
  * Represents the SQL INSERT statement for multiple rows.
  * One instance is always locked to one table and some of its columns based on constructor.
@@ -34,7 +36,7 @@ module.exports = class Batch {
 		const definition = await this.#query.getDefinition(this.database, this.table);
 		for (const column of columns) {
 			if (definition.columns.every(col => column !== col.name)) {
-				throw new sb.Error({
+				throw new SupiError({
 					message: "Unrecognized Batch column",
 					args: {
 						database: this.database,
@@ -56,7 +58,7 @@ module.exports = class Batch {
 		for (const key of Object.keys(data)) {
 			const column = this.columns.find(i => i.name === key);
 			if (!column) {
-				throw new sb.Error({
+				throw new SupiError({
 					message: "Invalid batch column provided",
 					args: {
 						column: key,
@@ -96,7 +98,7 @@ module.exports = class Batch {
 
 		const { duplicate, ignore } = options;
 		if (duplicate && ignore) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot set ignore and duplicate at the same time"
 			});
 		}

--- a/singletons/query/batch.js
+++ b/singletons/query/batch.js
@@ -4,7 +4,7 @@ import SupiError from "../../objects/error.js";
  * Represents the SQL INSERT statement for multiple rows.
  * One instance is always locked to one table and some of its columns based on constructor.
  */
-module.exports = class Batch {
+export default class Batch {
 	/** @type {QuerySingleton} */
 	#query;
 	#transaction;

--- a/singletons/query/index.js
+++ b/singletons/query/index.js
@@ -1,5 +1,5 @@
-import SupiDate from "../../objects/date";
-import SupiError from "../../objects/error";
+import SupiDate from "../../objects/date.js";
+import SupiError from "../../objects/error.js";
 
 import { createPool as createMariaDbPool } from "mariadb";
 import Batch from "./batch.js";

--- a/singletons/query/record-deleter.js
+++ b/singletons/query/record-deleter.js
@@ -1,4 +1,4 @@
-import SupiError from "../../objects/error";
+import SupiError from "../../objects/error.js";
 
 /**
  * Represents the UPDATE sql statement.

--- a/singletons/query/record-deleter.js
+++ b/singletons/query/record-deleter.js
@@ -1,7 +1,9 @@
+import SupiError from "../../objects/error";
+
 /**
  * Represents the UPDATE sql statement.
  */
-module.exports = class RecordDeleter {
+export default class RecordDeleter {
 	#query;
 	#transaction;
 	#deleteFrom = { database: null, table: null };
@@ -58,11 +60,11 @@ module.exports = class RecordDeleter {
 	/**
 	 * Translates the RecordDeleter to its SQL representation.
 	 * @returns {Promise<string[]>}
-	 * @throws {sb.Error} If no FROM database/table have been provided.
+	 * @throws {SupiError} If no FROM database/table have been provided.
 	 */
 	async toSQL () {
 		if (!this.#deleteFrom.database || !this.#deleteFrom.table) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "No UPDATE database/table in RecordUpdater - invalid definition"
 			});
 		}
@@ -74,7 +76,7 @@ module.exports = class RecordDeleter {
 			sql.push(`WHERE (${this.#where.join(") AND (")})`);
 		}
 		else if (!this.#confirmedFullDelete) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Unconfirmed full table deletion",
 				args: {
 					from: this.#deleteFrom
@@ -94,4 +96,4 @@ module.exports = class RecordDeleter {
 		const sqlString = sql.join("\n");
 		return await this.#query.transactionQuery(sqlString, this.#transaction);
 	}
-};
+}

--- a/singletons/query/record-updater.js
+++ b/singletons/query/record-updater.js
@@ -1,4 +1,4 @@
-import SupiError from "../../objects/error";
+import SupiError from "../../objects/error.js";
 
 /**
  * Represents the UPDATE sql statement.

--- a/singletons/query/record-updater.js
+++ b/singletons/query/record-updater.js
@@ -1,7 +1,9 @@
+import SupiError from "../../objects/error";
+
 /**
  * Represents the UPDATE sql statement.
  */
-module.exports = class RecordUpdater {
+export default class RecordUpdater {
 	#query;
 	#transaction;
 	#update = { database: null, table: null };
@@ -19,7 +21,7 @@ module.exports = class RecordUpdater {
 
 	priority (value) {
 		if (!["normal", "low"].includes(value)) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Incorrect priority value",
 				args: { value }
 			});
@@ -73,12 +75,12 @@ module.exports = class RecordUpdater {
 
 	async toSQL () {
 		if (!this.#update.database || !this.#update.table) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "No UPDATE database/table in RecordUpdater - invalid definition"
 			});
 		}
 		else if (this.#set.length === 0) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "No SET in RecordUpdater - invalid definition"
 			});
 		}
@@ -94,7 +96,7 @@ module.exports = class RecordUpdater {
 		for (const { column, value } of this.#set) {
 			const definition = columns.find(i => i.name === column);
 			if (!definition) {
-				throw new sb.Error({
+				throw new SupiError({
 					message: `Unrecognized column "${column}"`
 				});
 			}
@@ -120,4 +122,4 @@ module.exports = class RecordUpdater {
 		const sqlString = sql.join("\n");
 		return await this.#query.transactionQuery(sqlString, this.#transaction);
 	}
-};
+}

--- a/singletons/query/recordset.js
+++ b/singletons/query/recordset.js
@@ -1,4 +1,4 @@
-import SupiError from "../../objects/error";
+import SupiError from "../../objects/error.js";
 
 const ROW_COLLAPSED = Symbol("row-collapsed");
 

--- a/singletons/query/recordset.js
+++ b/singletons/query/recordset.js
@@ -1,6 +1,8 @@
+import SupiError from "../../objects/error";
+
 const ROW_COLLAPSED = Symbol("row-collapsed");
 
-module.exports = class Recordset {
+export default class Recordset {
 	#query;
 	#transaction;
 	#fetchSingle = false;
@@ -43,7 +45,7 @@ module.exports = class Recordset {
 		this.#limit = Number(number);
 
 		if (!Number.isFinite(this.#limit)) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Limit must be a finite number",
 				args: number
 			});
@@ -56,7 +58,7 @@ module.exports = class Recordset {
 		this.#offset = Number(number);
 
 		if (!Number.isFinite(this.#offset)) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Offset must be a finite number",
 				args: number
 			});
@@ -72,7 +74,7 @@ module.exports = class Recordset {
 
 	from (database, table) {
 		if (!database || !table) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Recordset: database and table must be provided",
 				args: {
 					db: database,
@@ -137,7 +139,7 @@ module.exports = class Recordset {
 			this.#having = this.#having.concat(format);
 		}
 		else {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Recordset: Unrecognized condition wrapper option",
 				args: { type, args }
 			});
@@ -166,7 +168,7 @@ module.exports = class Recordset {
 			} = database;
 
 			if (!toTable || !toDatabase) {
-				throw new sb.Error({
+				throw new SupiError({
 					message: "Missing compulsory arguments for join",
 					args: target
 				});
@@ -274,7 +276,7 @@ module.exports = class Recordset {
 			});
 		}
 		else {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Too many missing table specifications"
 			});
 		}
@@ -297,7 +299,7 @@ module.exports = class Recordset {
 		}
 
 		if (this.#select.length === 0) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "No SELECT in Recordset - invalid definition"
 			});
 		}
@@ -337,7 +339,7 @@ module.exports = class Recordset {
 		let result = [];
 		for (const row of rows) {
 			if (this.#flat && typeof row[this.#flat] === "undefined") {
-				throw new sb.Error({
+				throw new SupiError({
 					message: `Column ${this.#flat} is not included in the result`,
 					args: {
 						column: this.#flat,
@@ -424,4 +426,4 @@ module.exports = class Recordset {
 			}
 		}
 	}
-};
+}

--- a/singletons/query/row.js
+++ b/singletons/query/row.js
@@ -1,7 +1,9 @@
+import SupiError from "../../objects/error";
+
 /**
  * Represents one row of a SQL database table.
  */
-module.exports = class Row {
+export default class Row {
 	/** @type {TableDefinition} */
 	#definition;
 	/** @type {QuerySingleton} */
@@ -14,13 +16,13 @@ module.exports = class Row {
 	#valueProxy = new Proxy(this.#values, {
 		get: (target, name) => {
 			if (!this.#initialized) {
-				throw new sb.Error({
+				throw new SupiError({
 					message: "Cannot get row value - row not initialized",
 					args: this._getErrorInfo()
 				});
 			}
 			else if (typeof target[name] === "undefined") {
-				throw new sb.Error({
+				throw new SupiError({
 					message: `Cannot get row value - column "${name}" does not exist`,
 					args: this._getErrorInfo()
 				});
@@ -30,13 +32,13 @@ module.exports = class Row {
 		},
 		set: (target, name, value) => {
 			if (!this.#initialized) {
-				throw new sb.Error({
+				throw new SupiError({
 					message: "Cannot set row value - row not initialized",
 					args: this._getErrorInfo()
 				});
 			}
 			else if (typeof target[name] === "undefined") {
-				throw new sb.Error({
+				throw new SupiError({
 					message: `Cannot set row value - column "${name}" does not exist`,
 					args: this._getErrorInfo()
 				});
@@ -58,7 +60,7 @@ module.exports = class Row {
 
 	async initialize (database, table) {
 		if (!database || !table) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot initialize row - missing database/table",
 				args: { database, table }
 			});
@@ -80,20 +82,20 @@ module.exports = class Row {
 
 	async load (primaryKey, ignoreError = false) {
 		if (!this.#initialized) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot load row - not initialized",
 				args: this._getErrorInfo()
 			});
 		}
 
 		if (primaryKey === null || typeof primaryKey === "undefined") {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot load Row - no primary key provided",
 				args: this._getErrorInfo()
 			});
 		}
 		else if (this.#primaryKeyFields.length === 0) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot load Row - table has no primary keys",
 				args: this._getErrorInfo()
 			});
@@ -106,7 +108,7 @@ module.exports = class Row {
 			for (const [key, value] of Object.entries(primaryKey)) {
 				const column = this.#definition.columns.find(i => i.name === key);
 				if (!column) {
-					throw new sb.Error({
+					throw new SupiError({
 						message: `Cannot load Row - unrecognized column "${key}"`,
 						args: {
 							...this._getErrorInfo(),
@@ -115,7 +117,7 @@ module.exports = class Row {
 					});
 				}
 				else if (!column.primaryKey) {
-					throw new sb.Error({
+					throw new SupiError({
 						message: `Cannot load Row - column "${key}" is not primary`,
 						args: {
 							...this._getErrorInfo(),
@@ -133,7 +135,7 @@ module.exports = class Row {
 		else {
 			if (this.#primaryKeyFields.length > 1) {
 				const pks = this.#primaryKeyFields.map(i => i.name);
-				throw new sb.Error({
+				throw new SupiError({
 					message: "Cannot use implied PK - table has multiple PKs",
 					args: {
 						...this._getErrorInfo(),
@@ -157,7 +159,7 @@ module.exports = class Row {
 				return this;
 			}
 			else {
-				throw new sb.Error({
+				throw new SupiError({
 					message: "No row data found for provided primary key(s)",
 					args: {
 						...this._getErrorInfo(),
@@ -179,7 +181,7 @@ module.exports = class Row {
 
 	async save (options = {}) {
 		if (!this.#initialized) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot save row - not initialized",
 				args: this._getErrorInfo()
 			});
@@ -241,7 +243,7 @@ module.exports = class Row {
 
 	async delete () {
 		if (!this.#initialized) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot delete row - not initialized",
 				args: this._getErrorInfo()
 			});
@@ -257,7 +259,7 @@ module.exports = class Row {
 			this.#deleted = true;
 		}
 		else {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Row is not loaded - cannot delete",
 				args: this._getErrorInfo()
 			});
@@ -266,7 +268,7 @@ module.exports = class Row {
 
 	reset () {
 		if (!this.#initialized) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot reset row - not initialized",
 				args: this._getErrorInfo()
 			});
@@ -281,7 +283,7 @@ module.exports = class Row {
 
 	setValues (data) {
 		if (!this.#initialized) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot set column values - row not initialized",
 				args: this._getErrorInfo()
 			});
@@ -296,7 +298,7 @@ module.exports = class Row {
 
 	hasProperty (property) {
 		if (!this.#initialized) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Cannot check property - row not initialized",
 				args: this._getErrorInfo()
 			});

--- a/singletons/query/row.js
+++ b/singletons/query/row.js
@@ -1,4 +1,4 @@
-import SupiError from "../../objects/error";
+import SupiError from "../../objects/error.js";
 
 /**
  * Represents one row of a SQL database table.

--- a/singletons/query/row.js
+++ b/singletons/query/row.js
@@ -348,4 +348,4 @@ export default class Row {
 	get deleted () { return this.#deleted; }
 	get initialized () { return this.#initialized; }
 	get loaded () { return this.#loaded; }
-};
+}

--- a/singletons/utils.js
+++ b/singletons/utils.js
@@ -1,5 +1,17 @@
 // @todo refactor out all usages of sb.Got - this module must not rely on its "requirees" to properly import specific instances!
 
+import { MersenneTwister19937, Random } from "random-js";
+import getInfoFfprobe from "ffprobe";
+import { roll } from "roll-dice";
+import { transliterate } from "transliteration";
+import { load as loadCheerio } from "cheerio";
+import { parse as parseChrono } from "chrono-node";
+import RSSParser from "rss-parser";
+import parseDuration from "duration-parser";
+
+const rssParser = new RSSParser();
+const randomizer = new Random(MersenneTwister19937.autoSeed());
+
 const byteUnits = {
 	si: {
 		multiplier: 1000,
@@ -11,58 +23,12 @@ const byteUnits = {
 	}
 };
 
-const moduleMap = {
-	cheerio: () => require("cheerio"),
-	chrono: () => require("chrono-node"),
-	linkParser: () => {
-		const LinkParserFactory = require("track-link-parser");
-		return new LinkParserFactory({
-			youtube: {
-				key: sb.Config.get("API_GOOGLE_YOUTUBE")
-			},
-			bilibili: {
-				appKey: sb.Config.get("BILIBILI_APP_KEY"),
-				token: sb.Config.get("BILIBILI_PRIVATE_TOKEN"),
-				userAgentDescription: sb.Config.get("BILIBILI_USER_AGENT")
-			},
-			soundcloud: {
-				key: sb.Config.get("SOUNDCLOUD_CLIENT_ID")
-			}
-		});
-	},
-	languageISO: () => require("language-iso-codes"),
-	rss: () => new (require("rss-parser"))(),
-	random: () => {
-		const RandomJS = require("random-js");
-		return new RandomJS.Random(RandomJS.MersenneTwister19937.autoSeed());
-	},
-	parseDuration: () => require("duration-parser"),
-	ffprobe: () => require("ffprobe"),
-	transliterate: () => require("transliteration").transliterate
-};
-
-const RollDice = require("roll-dice");
-
 const linkRegex = /(((http|https):\/\/)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&/=]*))/gi;
-
-// this object has the same keys as `moduleMap`, but all values are `null`.
-const modules = Object.seal(Object.fromEntries(Object.keys(moduleMap).map(i => [i, null])));
-
-/** @type {Proxy} */
-const moduleProxy = new Proxy(modules, {
-	get: function (target, property) {
-		if (!modules[property]) {
-			modules[property] = moduleMap[property]();
-		}
-
-		return modules[property];
-	}
-});
 
 /**
  * Conscise collection of "helper" and "utility" methods.
  */
-module.exports = class UtilsSingleton {
+export default class Utils {
 	/** Numeric constants to convert between any two time units. */
 	static timeUnits = {
 		y: { d: 365, h: 8760, m: 525600, s: 31536000, ms: 31536000.0e3 },
@@ -116,23 +82,6 @@ module.exports = class UtilsSingleton {
 	};
 
 	/**
-	 * @returns {UtilsModuleProxyWrapper}
-	 */
-	get modules () {
-		return moduleProxy;
-	}
-
-	get languageISO () {
-		console.warn("Deprecated access Utils.languageISO");
-		return this.modules.languageISO;
-	}
-
-	get linkParser () {
-		console.warn("Deprecated access Utils.linkParser");
-		return this.modules.linkParser;
-	}
-
-	/**
 	 * Capitalizes the string's first letter.
 	 * @param {string} string
 	 * @returns {string}
@@ -171,36 +120,36 @@ module.exports = class UtilsSingleton {
 		const delta = Math.abs(deltaTo.valueOf() - target.valueOf());
 		const [prefix, suffix] = (target > deltaTo) ? ["in ", ""] : ["", " ago"];
 
-		if (delta < UtilsSingleton.timeUnits.s.ms) {
+		if (delta < Utils.timeUnits.s.ms) {
 			string = `${delta}ms`;
 		}
-		else if (delta < UtilsSingleton.timeUnits.m.ms) {
-			string = `${this.round(delta / UtilsSingleton.timeUnits.s.ms, 2)}s`;
+		else if (delta < Utils.timeUnits.m.ms) {
+			string = `${this.round(delta / Utils.timeUnits.s.ms, 2)}s`;
 		}
-		else if (delta < UtilsSingleton.timeUnits.h.ms) {
+		else if (delta < Utils.timeUnits.h.ms) {
 			// Discards the data carried in the last 3 digits, aka milliseconds.
 			// E.g. 119999ms should be parsed as "2min, 0sec"; not "1min, 59sec" because of a single millisecond.
 			// Rounding to -3 turns 119999 to 120000, which makes the rounding work properly.
 			const trimmed = this.round(delta, -3);
 
-			const minutes = Math.trunc(trimmed / UtilsSingleton.timeUnits.m.ms);
-			const seconds = Math.trunc((trimmed / UtilsSingleton.timeUnits.s.ms) % UtilsSingleton.timeUnits.m.s);
+			const minutes = Math.trunc(trimmed / Utils.timeUnits.m.ms);
+			const seconds = Math.trunc((trimmed / Utils.timeUnits.s.ms) % Utils.timeUnits.m.s);
 			string = `${minutes}m, ${seconds}s`;
 		}
-		else if (delta < UtilsSingleton.timeUnits.d.ms) {
+		else if (delta < Utils.timeUnits.d.ms) {
 			// Removing one millisecond from a time delta in (hours, minutes) should not affect the result.
 			const trimmed = this.round(delta, -3);
 
-			const hours = Math.trunc(trimmed / UtilsSingleton.timeUnits.h.ms);
-			const minutes = Math.trunc(trimmed / UtilsSingleton.timeUnits.m.ms) % UtilsSingleton.timeUnits.h.m;
+			const hours = Math.trunc(trimmed / Utils.timeUnits.h.ms);
+			const minutes = Math.trunc(trimmed / Utils.timeUnits.m.ms) % Utils.timeUnits.h.m;
 			string = `${hours}h, ${minutes}m`;
 		}
-		else if (delta < UtilsSingleton.timeUnits.y.ms) {
+		else if (delta < Utils.timeUnits.y.ms) {
 			// Removing any amount of milliseconds from a time delta in (days, minutes) should not affect the result.
 			const trimmed = this.round(delta, -3);
 
-			const days = Math.trunc(trimmed / UtilsSingleton.timeUnits.d.ms);
-			const hours = Math.trunc(trimmed / UtilsSingleton.timeUnits.h.ms) % UtilsSingleton.timeUnits.d.h;
+			const days = Math.trunc(trimmed / Utils.timeUnits.d.ms);
+			const hours = Math.trunc(trimmed / Utils.timeUnits.h.ms) % Utils.timeUnits.d.h;
 			string = `${days}d, ${hours}h`;
 		}
 		else if (respectLeapYears) { // 365 days or more
@@ -232,7 +181,7 @@ module.exports = class UtilsSingleton {
 
 			// Calculate number of remaining days
 			const remainingDelta = this.round(laterRounded.valueOf() - earlierPlusYears.valueOf(), -4);
-			const days = Math.trunc(remainingDelta / UtilsSingleton.timeUnits.d.ms);
+			const days = Math.trunc(remainingDelta / Utils.timeUnits.d.ms);
 
 			string = `${years}y, ${days}d`;
 		}
@@ -240,8 +189,8 @@ module.exports = class UtilsSingleton {
 			// Removing any amount of seconds from a time delta in (years, days) should not affect the result.
 			const trimmed = this.round(delta, -4);
 
-			const years = Math.trunc(trimmed / UtilsSingleton.timeUnits.y.ms);
-			const days = Math.trunc(trimmed / UtilsSingleton.timeUnits.d.ms) % UtilsSingleton.timeUnits.y.d;
+			const years = Math.trunc(trimmed / Utils.timeUnits.y.ms);
+			const days = Math.trunc(trimmed / Utils.timeUnits.d.ms) % Utils.timeUnits.y.d;
 			string = `${years}y, ${days}d`;
 		}
 
@@ -315,7 +264,7 @@ module.exports = class UtilsSingleton {
 	fixHTML (string) {
 		return string.replace(/&#?(?<identifier>[a-z0-9]+);/g, (...params) => {
 			const { identifier } = params.pop();
-			return UtilsSingleton.htmlEntities[identifier] || String.fromCharCode(Number(identifier));
+			return Utils.htmlEntities[identifier] || String.fromCharCode(Number(identifier));
 		});
 	}
 
@@ -363,7 +312,7 @@ module.exports = class UtilsSingleton {
 	 * @returns {number}
 	 */
 	random (min, max) {
-		return this.modules.random.integer(min, max);
+		return randomizer.integer(min, max);
 	}
 
 	/**
@@ -408,33 +357,33 @@ module.exports = class UtilsSingleton {
 		if (videoStyle) {
 			seconds = Math.trunc(seconds);
 
-			if (seconds >= UtilsSingleton.timeUnits.h.s) {
-				const hr = Math.floor(seconds / UtilsSingleton.timeUnits.h.s);
+			if (seconds >= Utils.timeUnits.h.s) {
+				const hr = Math.floor(seconds / Utils.timeUnits.h.s);
 				stuff.push(hr);
-				seconds -= (hr * UtilsSingleton.timeUnits.h.s);
+				seconds -= (hr * Utils.timeUnits.h.s);
 			}
-			const min = Math.floor(seconds / UtilsSingleton.timeUnits.m.s);
+			const min = Math.floor(seconds / Utils.timeUnits.m.s);
 			stuff.push((stuff.length) ? this.zf(min, 2) : min);
-			seconds -= (min * UtilsSingleton.timeUnits.m.s);
+			seconds -= (min * Utils.timeUnits.m.s);
 			stuff.push(this.zf(seconds, 2));
 
 			return stuff.join(":");
 		}
 		else {
-			if (seconds >= UtilsSingleton.timeUnits.d.s) {
-				const days = Math.floor(seconds / UtilsSingleton.timeUnits.d.s);
+			if (seconds >= Utils.timeUnits.d.s) {
+				const days = Math.floor(seconds / Utils.timeUnits.d.s);
 				stuff.push(`${days} days`);
-				seconds -= (days * UtilsSingleton.timeUnits.d.s);
+				seconds -= (days * Utils.timeUnits.d.s);
 			}
-			if (seconds >= UtilsSingleton.timeUnits.h.s) {
-				const hr = Math.floor(seconds / UtilsSingleton.timeUnits.h.s);
+			if (seconds >= Utils.timeUnits.h.s) {
+				const hr = Math.floor(seconds / Utils.timeUnits.h.s);
 				stuff.push(`${hr} hr`);
-				seconds -= (hr * UtilsSingleton.timeUnits.h.s);
+				seconds -= (hr * Utils.timeUnits.h.s);
 			}
-			if (seconds >= UtilsSingleton.timeUnits.m.s) {
-				const min = Math.floor(seconds / UtilsSingleton.timeUnits.m.s);
+			if (seconds >= Utils.timeUnits.m.s) {
+				const min = Math.floor(seconds / Utils.timeUnits.m.s);
 				stuff.push(`${min} min`);
-				seconds -= (min * UtilsSingleton.timeUnits.m.s);
+				seconds -= (min * Utils.timeUnits.m.s);
 			}
 			if (seconds >= 0 || stuff.length === 0) {
 				stuff.push(`${this.round(seconds, 3)} sec`);
@@ -695,7 +644,7 @@ module.exports = class UtilsSingleton {
 	 * @returns {number|{time: number, ranges: Object[]}}
 	 */
 	parseDuration (string, options) {
-		return this.modules.parseDuration(string, options);
+		return parseDuration(string, options);
 	}
 
 	/**
@@ -723,7 +672,7 @@ module.exports = class UtilsSingleton {
 	}
 
 	parseChrono (string, referenceDate = null, options = {}) {
-		const chronoData = this.modules.chrono.parse(string, referenceDate, options);
+		const chronoData = parseChrono(string, referenceDate, options);
 		if (chronoData.length === 0) {
 			return null;
 		}
@@ -807,7 +756,7 @@ module.exports = class UtilsSingleton {
 	 * @returns {string}
 	 */
 	transliterate (...args) {
-		return this.modules.transliterate(...args);
+		return transliterate(...args);
 	}
 
 	/**
@@ -871,8 +820,7 @@ module.exports = class UtilsSingleton {
 	 * @returns {*} CheerioAPI
 	 */
 	cheerio (html) {
-		const cheerio = require("cheerio");
-		return cheerio.load(html);
+		return loadCheerio(html);
 	}
 
 	/**
@@ -1154,7 +1102,7 @@ module.exports = class UtilsSingleton {
 	 * @returns {Promise<RSSParserResult>}
 	 */
 	async parseRSS (xml) {
-		return await this.modules.rss.parseString(xml);
+		return await rssParser.parseString(xml);
 	}
 
 	/**
@@ -1165,7 +1113,7 @@ module.exports = class UtilsSingleton {
 	async getMediaFileData (link) {
 		try {
 			const path = sb.Config.get("FFMPEG_PATH");
-			const { streams } = await this.modules.ffprobe(link, { path });
+			const { streams } = await getInfoFfprobe(link, { path });
 			return {
 				duration: Number(streams[0].duration),
 				bitrate: Number(streams[0].bit_rate)
@@ -1262,7 +1210,7 @@ module.exports = class UtilsSingleton {
 		const seed = this.random(0, 1e12);
 		const resultLimit = limit ?? Number.MAX_SAFE_INTEGER;
 		try {
-			return Number(RollDice.roll(input, BigInt(seed), BigInt(resultLimit)));
+			return Number(roll(input, BigInt(seed), BigInt(resultLimit)));
 		}
 		catch {
 			return null;
@@ -1615,7 +1563,7 @@ module.exports = class UtilsSingleton {
 	destroy () {
 		this.duration = null;
 	}
-};
+}
 
 /**
  * @typedef {Object} NSFWDetectionResult
@@ -1663,18 +1611,4 @@ module.exports = class UtilsSingleton {
  * @property {string} link
  * @property {string} pubDate
  * @property {string} title
- */
-
-/**
- * @typedef {Proxy} UtilsModuleProxyWrapper
- * @property {TrackLinkParser} linkParser
- * @property {function} cheerio Fast, flexible & lean implementation of core jQuery designed specifically for the server.
- * @property {function} chrono A natural language date parser in Javascript. It is designed to handle most date/time format and extract information from any given text.
- * @property {ISOLanguageParser} languageISO
- * @property {Object} random
- * @property {Object} rss
- * @property {DurationParserModuleFunction} parseDuration
- * @property {function} ffprobe
- * @property {function} diceRollEval
- * @property {function} transliterate
  */

--- a/singletons/utils.js
+++ b/singletons/utils.js
@@ -1,5 +1,8 @@
 // @todo refactor out all usages of sb.Got - this module must not rely on its "requirees" to properly import specific instances!
 
+import SupiDate from "../objects/date.js";
+import SupiError from "../objects/error.js";
+
 import { MersenneTwister19937, Random } from "random-js";
 import getInfoFfprobe from "ffprobe";
 import { roll } from "roll-dice";
@@ -92,27 +95,27 @@ export default class Utils {
 
 	/**
 	 * Returns a formatted string, specifying an amount of time delta from current date to provided date.
-	 * @param {sb.Date|Date|number} target
+	 * @param {SupiDate|Date|number} target
 	 * @param {boolean} [skipAffixes] if true, the affixes "in X hours" or "X hours ago" will be omitted
 	 * @param {boolean} [respectLeapYears] If true, shows a time difference spanning a whole year as `1y` regardless
 	 * of the actual length of the year. If disabled, a year is always counted to be 365 * 24 hours. Defaults to false
-	 * @param {sb.Date} [deltaTo] If set, calculate time delta between target and deltaTo. If undefined, calculate
+	 * @param {SupiDate} [deltaTo] If set, calculate time delta between target and deltaTo. If undefined, calculate
 	 * delta between target and the current time.
 	 * @returns {string}
 	 */
 	timeDelta (target, skipAffixes = false, respectLeapYears = false, deltaTo = undefined) {
 		if (deltaTo === undefined) {
-			deltaTo = new sb.Date();
+			deltaTo = new SupiDate();
 		}
 
 		if (target.valueOf && typeof target.valueOf() === "number") {
-			target = new sb.Date(target.valueOf());
+			target = new SupiDate(target.valueOf());
 		}
 		else {
 			throw new TypeError("Invalid parameter type");
 		}
 
-		if (sb.Date.equals(deltaTo, target)) {
+		if (SupiDate.equals(deltaTo, target)) {
 			return "right now!";
 		}
 
@@ -158,7 +161,7 @@ export default class Utils {
 			// Removing any amount of milliseconds from a time delta in (days, minutes) should not affect the result.
 			const trimmed = this.round(delta, -3);
 
-			const laterRounded = new sb.Date(earlier.valueOf() + trimmed);
+			const laterRounded = new SupiDate(earlier.valueOf() + trimmed);
 
 			// how many whole years lie between the dates?
 			let years = laterRounded.getUTCFullYear() - earlier.getUTCFullYear();
@@ -233,7 +236,7 @@ export default class Utils {
 	round (number, places = 0, options = {}) {
 		const direction = options.direction ?? "round";
 		if (!["ceil", "floor", "round", "trunc"].includes(direction)) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Invalid round direction provided",
 				args: { number, places, options }
 			});
@@ -287,7 +290,7 @@ export default class Utils {
 	 */
 	wrapString (string, length, options = {}) {
 		if (typeof string !== "string") {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Provided input must be a string",
 				args: {
 					type: typeof string,
@@ -425,7 +428,7 @@ export default class Utils {
 		const params = { ...options };
 		if (params.single) {
 			if (typeof params.maxResults !== "undefined") {
-				throw new sb.Error({
+				throw new SupiError({
 					message: "Cannot combine params maxResults and single"
 				});
 			}
@@ -472,12 +475,12 @@ export default class Utils {
 	 */
 	async fetchYoutubePlaylist (options = {}) {
 		if (!options.key) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "No API key provided"
 			});
 		}
 		else if (!options.playlistID) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "No playlist ID provided"
 			});
 		}
@@ -517,7 +520,7 @@ export default class Utils {
 				ID: i.snippet.resourceId.videoId,
 				title: i.snippet.title,
 				channelTitle: i.snippet.channelTitle,
-				published: new sb.Date(i.snippet.publishedAt),
+				published: new SupiDate(i.snippet.publishedAt),
 				position: i.snippet.position
 			})));
 
@@ -526,7 +529,7 @@ export default class Utils {
 			}
 			else if (data.pageInfo.totalResults > limit) {
 				if (options.limitAction === "error") {
-					throw new sb.Error({
+					throw new SupiError({
 						message: "Maximum amount of videos exceeded!",
 						args: {
 							limit,
@@ -687,7 +690,7 @@ export default class Utils {
 
 	convertCase (text, caseFrom, caseTo) {
 		if (typeof text !== "string") {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Text must be typeof string",
 				args: { text, caseFrom, caseTo }
 			});
@@ -767,7 +770,7 @@ export default class Utils {
 	 */
 	splitByCondition (array, filter) {
 		if (!Array.isArray(array)) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "array must be an Array"
 			});
 		}
@@ -832,7 +835,7 @@ export default class Utils {
 	 */
 	formatByteSize (number, digits = 3, type = "si") {
 		if (type !== "si" && type !== "iec") {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Unsupported byte size format",
 				args: { number, type }
 			});
@@ -868,7 +871,7 @@ export default class Utils {
 			characters = characters.split("");
 		}
 		else if (!Array.isArray(characters) || characters.some(i => typeof i !== "string")) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Invalid input format",
 				args: { characters, length }
 			});
@@ -1152,7 +1155,7 @@ export default class Utils {
 	 */
 	partitionString (message, limit, messageCount) {
 		if (!this.isValidInteger(limit)) {
-			throw new sb.Error({
+			throw new SupiError({
 				message: "Limit must be a positive integer"
 			});
 		}
@@ -1339,13 +1342,13 @@ export default class Utils {
 	 * @param {Object} data.coordinates
 	 * @param {string} data.coordinates.lng
 	 * @param {string} data.coordinates.lat
-	 * @param {Date|sb.Date|number} data.date = new sb.Date()
+	 * @param {Date|SupiDate|number} data.date = new SupiDate()
 	 * @returns {Promise<{body: Object, statusCode: number}>}
 	 */
 	async fetchTimeData (data = {}) {
 		const {
 			coordinates,
-			date = new sb.Date(),
+			date = new SupiDate(),
 			key
 		} = data;
 

--- a/tests/date.test.js
+++ b/tests/date.test.js
@@ -1,8 +1,5 @@
-const assert = require("assert");
-
-globalThis.sb = {
-	Date: require("../objects/date")
-};
+import assert from "assert";
+import SupiDate from "../objects/date.js";
 
 /**
  * Generates an Array pre-filled with the index
@@ -11,51 +8,51 @@ globalThis.sb = {
  */
 const simpleRange = (length) => [...new Array(length)].map((_, idx) => idx);
 
-describe("sb.Date", () => {
+describe("SupiDate", () => {
 	describe("getDaySuffix", () => {
 		it("should return the correct suffix", () => {
 			assert.deepEqual(
-				[1, 2, 3, 4, 11, 12, 13, 21, 22, 23].map(i => sb.Date.getDaySuffix(i)),
+				[1, 2, 3, 4, 11, 12, 13, 21, 22, 23].map(i => SupiDate.getDaySuffix(i)),
 				["st", "nd", "rd", "th", "th", "th", "th", "st", "nd", "rd"]);
 		});
 		it("should throw if the number isn't an integer", () => {
-			assert.throws(() => sb.Date.getDaySuffix(1.1));
+			assert.throws(() => SupiDate.getDaySuffix(1.1));
 		});
 		it("should throw if the input isn't a number", () => {
-			assert.throws(() => sb.Date.getDaySuffix("1"));
-			assert.throws(() => sb.Date.getDaySuffix(undefined));
-			assert.throws(() => sb.Date.getDaySuffix(null));
+			assert.throws(() => SupiDate.getDaySuffix("1"));
+			assert.throws(() => SupiDate.getDaySuffix(undefined));
+			assert.throws(() => SupiDate.getDaySuffix(null));
 		});
 	});
 
 	describe("zf", () => {
 		it("should pad a number with leading zeros", () => {
-			assert.equal(sb.Date.zf(1, 3), "001");
-			assert.equal(sb.Date.zf(123, 3), "123");
+			assert.equal(SupiDate.zf(1, 3), "001");
+			assert.equal(SupiDate.zf(123, 3), "123");
 		});
 	});
 
 	describe("equals", () => {
 		it("should work with itself", () => {
-			assert(sb.Date.equals(new sb.Date(2020, 1, 1), new sb.Date(2020, 1, 1)));
-			assert(!sb.Date.equals(new sb.Date(2020, 1, 1), new sb.Date(2021, 1, 1)));
+			assert(SupiDate.equals(new SupiDate(2020, 1, 1), new SupiDate(2020, 1, 1)));
+			assert(!SupiDate.equals(new SupiDate(2020, 1, 1), new SupiDate(2021, 1, 1)));
 		});
 		it("should work with native dates", () => {
-			assert(sb.Date.equals(new sb.Date(2020, 1, 1), new Date(2020, 0, 1)));
-			assert(!sb.Date.equals(new sb.Date(2020, 1, 1), new Date(2021, 0, 1)));
+			assert(SupiDate.equals(new SupiDate(2020, 1, 1), new Date(2020, 0, 1)));
+			assert(!SupiDate.equals(new SupiDate(2020, 1, 1), new Date(2021, 0, 1)));
 		});
 		it("should work with the same object", () => {
-			const date = new sb.Date(2020, 1, 1);
-			assert(sb.Date.equals(date, date));
+			const date = new SupiDate(2020, 1, 1);
+			assert(SupiDate.equals(date, date));
 		});
 		it("should work with clones", () => {
-			const date = new sb.Date(2020, 1, 1);
+			const date = new SupiDate(2020, 1, 1);
 			const cloned = date.clone();
-			assert(sb.Date.equals(date, cloned));
+			assert(SupiDate.equals(date, cloned));
 		});
 		it("should throw on invalid dates", () => {
-			assert.throws(() => sb.Date.equals(new sb.Date(2021, 10, 1), null));
-			assert.throws(() => sb.Date.equals(null, new sb.Date(2021, 10, 1)));
+			assert.throws(() => SupiDate.equals(new SupiDate(2021, 10, 1), null));
+			assert.throws(() => SupiDate.equals(null, new SupiDate(2021, 10, 1)));
 		});
 	});
 
@@ -63,28 +60,28 @@ describe("sb.Date", () => {
 		describe("formatters", () => {
 			describe("l", () => {
 				it("should print the day of the week", () => {
-					const actual = simpleRange(7).map(i => new sb.Date(2021, 10, i + 1).format("l"));
+					const actual = simpleRange(7).map(i => new SupiDate(2021, 10, i + 1).format("l"));
 					const expected = ["Friday", "Saturday", "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday"];
 					assert.deepEqual(actual, expected);
 				});
 			});
 			describe("D", () => {
 				it("should print the short day of the week", () => {
-					const actual = simpleRange(7).map(i => new sb.Date(2021, 10, i + 1).format("D"));
+					const actual = simpleRange(7).map(i => new SupiDate(2021, 10, i + 1).format("D"));
 					const expected = ["Fri", "Sat", "Sun", "Mon", "Tue", "Wed", "Thu"];
 					assert.deepEqual(actual, expected);
 				});
 			});
 			describe("F", () => {
 				it("should print the month", () => {
-					const actual = simpleRange(12).map(i => new sb.Date(2021, i + 1, 1).format("F"));
+					const actual = simpleRange(12).map(i => new SupiDate(2021, i + 1, 1).format("F"));
 					const expected = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 					assert.deepEqual(actual, expected);
 				});
 			});
 			describe("M", () => {
 				it("should print the short month", () => {
-					const actual = simpleRange(12).map(i => new sb.Date(2021, i + 1, 1).format("M"));
+					const actual = simpleRange(12).map(i => new SupiDate(2021, i + 1, 1).format("M"));
 					const expected = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 					assert.deepEqual(actual, expected);
 				});
@@ -92,76 +89,76 @@ describe("sb.Date", () => {
 			describe("S", () => {
 				it("should print the day suffix", () => {
 					assert.deepEqual(
-						[1,2,3,4,11,12,13,21,22,23].map(i => new sb.Date(2021, 1, i).format("S")),
+						[1,2,3,4,11,12,13,21,22,23].map(i => new SupiDate(2021, 1, i).format("S")),
 						["st", "nd", "rd", "th", "th", "th", "th", "st", "nd", "rd"]);
 				});
 			});
 			describe("d", () => {
 				it("should print the padded day", () => {
-					assert.equal(new sb.Date(2021, 1, 2).format("d"), "02");
-					assert.equal(new sb.Date(2021, 1, 12).format("d"), "12");
+					assert.equal(new SupiDate(2021, 1, 2).format("d"), "02");
+					assert.equal(new SupiDate(2021, 1, 12).format("d"), "12");
 				});
 			});
 			describe("j", () => {
 				it("should print the day", () => {
-					assert.equal(new sb.Date(2021, 1, 2).format("j"), "2");
-					assert.equal(new sb.Date(2021, 1, 12).format("j"), "12");
+					assert.equal(new SupiDate(2021, 1, 2).format("j"), "2");
+					assert.equal(new SupiDate(2021, 1, 12).format("j"), "12");
 				});
 			});
 			describe("m", () => {
 				it("should print the padded month", () => {
-					assert.equal(new sb.Date(2021, 2, 1).format("m"), "02");
-					assert.equal(new sb.Date(2021, 12, 1).format("m"), "12");
+					assert.equal(new SupiDate(2021, 2, 1).format("m"), "02");
+					assert.equal(new SupiDate(2021, 12, 1).format("m"), "12");
 				});
 			});
 			describe("n", () => {
 				it("should print the month", () => {
-					assert.equal(new sb.Date(2021, 2, 1).format("n"), "2");
-					assert.equal(new sb.Date(2021, 12, 1).format("n"), "12");
+					assert.equal(new SupiDate(2021, 2, 1).format("n"), "2");
+					assert.equal(new SupiDate(2021, 12, 1).format("n"), "12");
 				});
 			});
 			describe("Y", () => {
 				it("should print the year", () => {
-					assert.equal(new sb.Date(2021, 1, 1).format("Y"), "2021");
+					assert.equal(new SupiDate(2021, 1, 1).format("Y"), "2021");
 				});
 			});
 			describe("G", () => {
 				it("should print the hour", () => {
-					assert.equal(new sb.Date(2021, 1, 1, 1).format("G"), "1");
-					assert.equal(new sb.Date(2021, 1, 1, 12).format("G"), "12");
+					assert.equal(new SupiDate(2021, 1, 1, 1).format("G"), "1");
+					assert.equal(new SupiDate(2021, 1, 1, 12).format("G"), "12");
 				});
 			});
 			describe("H", () => {
 				it("should print the padded hour", () => {
-					assert.equal(new sb.Date(2021, 1, 1, 1).format("H"), "01");
-					assert.equal(new sb.Date(2021, 1, 1, 12).format("H"), "12");
+					assert.equal(new SupiDate(2021, 1, 1, 1).format("H"), "01");
+					assert.equal(new SupiDate(2021, 1, 1, 12).format("H"), "12");
 				});
 			});
 			describe("i", () => {
 				it("should print the padded minute", () => {
-					assert.equal(new sb.Date(2021, 1, 1, 1, 1).format("i"), "01");
-					assert.equal(new sb.Date(2021, 1, 1, 1, 42).format("i"), "42");
+					assert.equal(new SupiDate(2021, 1, 1, 1, 1).format("i"), "01");
+					assert.equal(new SupiDate(2021, 1, 1, 1, 42).format("i"), "42");
 				});
 			});
 			describe("s", () => {
 				it("should print the padded minute", () => {
-					assert.equal(new sb.Date(2021, 1, 1, 1, 1, 1).format("s"), "01");
-					assert.equal(new sb.Date(2021, 1, 1, 1, 1, 42).format("s"), "42");
+					assert.equal(new SupiDate(2021, 1, 1, 1, 1, 1).format("s"), "01");
+					assert.equal(new SupiDate(2021, 1, 1, 1, 1, 42).format("s"), "42");
 				});
 			});
 			describe("v", () => {
 				it("should print the padded minute", () => {
-					assert.equal(new sb.Date(2021, 1, 1, 1, 1, 0, 1).format("v"), "001");
-					assert.equal(new sb.Date(2021, 1, 1, 1, 1, 0, 42).format("v"), "042");
-					assert.equal(new sb.Date(2021, 1, 1, 1, 1, 0, 187).format("v"), "187");
+					assert.equal(new SupiDate(2021, 1, 1, 1, 1, 0, 1).format("v"), "001");
+					assert.equal(new SupiDate(2021, 1, 1, 1, 1, 0, 42).format("v"), "042");
+					assert.equal(new SupiDate(2021, 1, 1, 1, 1, 0, 187).format("v"), "187");
 				});
 			});
 		});
 		it("should concat multiple formatters", () => {
-			assert.equal(new sb.Date(2021, 10, 1).format("Ymd"), "20211001");
+			assert.equal(new SupiDate(2021, 10, 1).format("Ymd"), "20211001");
 		});
 		it("should keep non formatter characters", () => {
-			assert.equal(new sb.Date(2021, 10, 1).format("Y-m-d"), "2021-10-01");
+			assert.equal(new SupiDate(2021, 10, 1).format("Y-m-d"), "2021-10-01");
 		});
 	});
 
@@ -186,7 +183,7 @@ describe("sb.Date", () => {
 
 			for (const value of values) {
 				let date;
-				assert.doesNotThrow(() => { date = new sb.Date(value); });
+				assert.doesNotThrow(() => { date = new SupiDate(value); });
 				assert.strictEqual(date.isValid(), true, `Date should be valid for value "${value}"`);
 			}
 		});
@@ -207,7 +204,7 @@ describe("sb.Date", () => {
 
 			for (const value of values) {
 				let date;
-				assert.doesNotThrow(() => { date = new sb.Date(value); });
+				assert.doesNotThrow(() => { date = new SupiDate(value); });
 				assert.strictEqual(date.isValid(), false, `Date should be invalid for value "${value}"`);
 			}
 		});
@@ -215,43 +212,43 @@ describe("sb.Date", () => {
 
 	describe("setTimezoneOffset", () => {
 		it("should apply the offset", () => {
-			const date = new sb.Date();
+			const date = new SupiDate();
 			const other = date.clone();
 			date.setTimezoneOffset(60);
 			other.addMinutes(other.getTimezoneOffset() + 60);
-			assert(sb.Date.equals(date, other));
+			assert(SupiDate.equals(date, other));
 		});
 		it("should only accept quarter hours", () => {
-			assert.throws(() => new sb.Date(2021, 10, 1).setTimezoneOffset(42));
-			assert.throws(() => new sb.Date(2021, 10, 1).setTimezoneOffset(NaN));
+			assert.throws(() => new SupiDate(2021, 10, 1).setTimezoneOffset(42));
+			assert.throws(() => new SupiDate(2021, 10, 1).setTimezoneOffset(NaN));
 		});
 	});
 
 	describe("discardTimeUnits", () => {
 		it("should discard hours", () => {
-			assert.equal(new sb.Date(2021, 10, 1, 12).discardTimeUnits("h").hours, 0);
+			assert.equal(new SupiDate(2021, 10, 1, 12).discardTimeUnits("h").hours, 0);
 		});
 		it("should discard minutes", () => {
-			assert.equal(new sb.Date(2021, 10, 1, 12, 42).discardTimeUnits("m").minutes, 0);
+			assert.equal(new SupiDate(2021, 10, 1, 12, 42).discardTimeUnits("m").minutes, 0);
 		});
 		it("should discard seconds", () => {
-			assert.equal(new sb.Date(2021, 10, 1, 12, 42, 43).discardTimeUnits("s").seconds, 0);
+			assert.equal(new SupiDate(2021, 10, 1, 12, 42, 43).discardTimeUnits("s").seconds, 0);
 		});
 		it("should discard milliseconds", () => {
-			assert.equal(new sb.Date(2021, 10, 1, 12, 42, 43, 44).discardTimeUnits("ms").milliseconds, 0);
+			assert.equal(new SupiDate(2021, 10, 1, 12, 42, 43, 44).discardTimeUnits("ms").milliseconds, 0);
 		});
 		it("should discard multiple units at once", () => {
-			const date = new sb.Date(2021, 10, 1, 12, 42, 43, 44).discardTimeUnits("h", "ms", "m");
+			const date = new SupiDate(2021, 10, 1, 12, 42, 43, 44).discardTimeUnits("h", "ms", "m");
 			assert.deepEqual([date.hours, date.minutes, date.seconds, date.milliseconds], [0, 0, 43, 0]);
 		});
 		it("should throw if an invalid unit is provided", () => {
-			assert.throws(() => new sb.Date(2021, 10, 1).discardTimeUnits("h", "Y"));
+			assert.throws(() => new SupiDate(2021, 10, 1).discardTimeUnits("h", "Y"));
 		});
 	});
 
 	describe("clone", () => {
 		it("should clone the object", () => {
-			const d1 = new sb.Date(2021, 10, 1);
+			const d1 = new SupiDate(2021, 10, 1);
 			const d2 = d1.clone();
 			d2.setHours(4);
 			assert.deepEqual([d1.hours, d2.hours], [0, 4]);
@@ -261,86 +258,86 @@ describe("sb.Date", () => {
 
 	describe("simpleDate", () => {
 		it("should format the date correctly", () => {
-			assert.equal(new sb.Date(2021, 9, 1).simpleDate(), "1.9.2021");
+			assert.equal(new SupiDate(2021, 9, 1).simpleDate(), "1.9.2021");
 		});
 	});
 
 	describe("simpleDateTime", () => {
 		it("should format the date correctly", () => {
-			assert.equal(new sb.Date(2021, 9, 1, 4, 2, 1).simpleDateTime(), "1.9.2021 04:02:01");
+			assert.equal(new SupiDate(2021, 9, 1, 4, 2, 1).simpleDateTime(), "1.9.2021 04:02:01");
 		});
 	});
 
 	describe("fullDateTime", () => {
 		it("should format the date correctly", () => {
-			assert.equal(new sb.Date(2021, 9, 1, 4, 2, 1, 55).fullDateTime(), "1.9.2021 04:02:01.055");
+			assert.equal(new SupiDate(2021, 9, 1, 4, 2, 1, 55).fullDateTime(), "1.9.2021 04:02:01.055");
 		});
 	});
 
 	describe("sqlDate", () => {
 		it("should format the date correctly", () => {
-			assert.equal(new sb.Date(2021, 9, 1).sqlDate(), "2021-09-01");
+			assert.equal(new SupiDate(2021, 9, 1).sqlDate(), "2021-09-01");
 		});
 	});
 
 	describe("sqlTime", () => {
 		it("should format the date correctly", () => {
-			assert.equal(new sb.Date(2021, 9, 1, 4, 2, 1, 55).sqlTime(), "04:02:01.055");
+			assert.equal(new SupiDate(2021, 9, 1, 4, 2, 1, 55).sqlTime(), "04:02:01.055");
 		});
 	});
 
 	describe("sqlDateTime", () => {
 		it("should format the date correctly", () => {
-			assert.equal(new sb.Date(2021, 9, 1, 4, 2, 1, 55).sqlDateTime(), "2021-09-01 04:02:01.055");
+			assert.equal(new SupiDate(2021, 9, 1, 4, 2, 1, 55).sqlDateTime(), "2021-09-01 04:02:01.055");
 		});
 	});
 
 	describe("setters", () => {
 		describe("year", () => {
 			it("should change the year", () => {
-				const date = new sb.Date(2021, 10, 1);
+				const date = new SupiDate(2021, 10, 1);
 				date.year += 1;
 				assert.equal(date.year, 2022);
 			});
 		});
 		describe("month", () => {
 			it("should change the month", () => {
-				const date = new sb.Date(2021, 12, 1);
+				const date = new SupiDate(2021, 12, 1);
 				date.month += 1;
 				assert.equal(date.month, 1);
 			});
 		});
 		describe("day", () => {
 			it("should change the day", () => {
-				const date = new sb.Date(2021, 10, 31);
+				const date = new SupiDate(2021, 10, 31);
 				date.day += 1;
 				assert.equal(date.day, 1);
 			});
 		});
 		describe("hour", () => {
 			it("should change the hour", () => {
-				const date = new sb.Date(2021, 10, 31, 23);
+				const date = new SupiDate(2021, 10, 31, 23);
 				date.hours += 1;
 				assert.equal(date.hours, 0);
 			});
 		});
 		describe("minutes", () => {
 			it("should change the minutes", () => {
-				const date = new sb.Date(2021, 10, 31, 23, 59);
+				const date = new SupiDate(2021, 10, 31, 23, 59);
 				date.minutes += 1;
 				assert.equal(date.minutes, 0);
 			});
 		});
 		describe("seconds", () => {
 			it("should change the seconds", () => {
-				const date = new sb.Date(2021, 10, 31, 23, 59, 59);
+				const date = new SupiDate(2021, 10, 31, 23, 59, 59);
 				date.seconds += 1;
 				assert.equal(date.seconds, 0);
 			});
 		});
 		describe("milliseconds", () => {
 			it("should change the milliseconds", () => {
-				const date = new sb.Date(2021, 10, 31, 23, 59, 59, 999);
+				const date = new SupiDate(2021, 10, 31, 23, 59, 59, 999);
 				date.milliseconds += 1;
 				assert.equal(date.milliseconds, 0);
 			});
@@ -350,49 +347,49 @@ describe("sb.Date", () => {
 	describe("add methods", () => {
 		describe("addYears", () => {
 			it("should change the year", () => {
-				const date = new sb.Date(2021, 10, 1);
+				const date = new SupiDate(2021, 10, 1);
 				date.addYears(1);
 				assert.equal(date.year, 2022);
 			});
 		});
 		describe("addMonths", () => {
 			it("should change the month", () => {
-				const date = new sb.Date(2021, 12, 1);
+				const date = new SupiDate(2021, 12, 1);
 				date.addMonths(1);
 				assert.equal(date.month, 1);
 			});
 		});
 		describe("addDays", () => {
 			it("should change the day", () => {
-				const date = new sb.Date(2021, 10, 31);
+				const date = new SupiDate(2021, 10, 31);
 				date.addDays(1);
 				assert.equal(date.day, 1);
 			});
 		});
 		describe("addHours", () => {
 			it("should change the hour", () => {
-				const date = new sb.Date(2021, 10, 31, 23);
+				const date = new SupiDate(2021, 10, 31, 23);
 				date.addHours(1);
 				assert.equal(date.hours, 0);
 			});
 		});
 		describe("addMinutes", () => {
 			it("should change the minutes", () => {
-				const date = new sb.Date(2021, 10, 31, 23, 59);
+				const date = new SupiDate(2021, 10, 31, 23, 59);
 				date.addMinutes(1);
 				assert.equal(date.minutes, 0);
 			});
 		});
 		describe("addSeconds", () => {
 			it("should change the seconds", () => {
-				const date = new sb.Date(2021, 10, 31, 23, 59, 59);
+				const date = new SupiDate(2021, 10, 31, 23, 59, 59);
 				date.addSeconds(1);
 				assert.equal(date.seconds, 0);
 			});
 		});
 		describe("addMilliseconds", () => {
 			it("should change the milliseconds", () => {
-				const date = new sb.Date(2021, 10, 31, 23, 59, 59, 999);
+				const date = new SupiDate(2021, 10, 31, 23, 59, 59, 999);
 				date.addMilliseconds(1);
 				assert.equal(date.milliseconds, 0);
 			});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,194 +1,181 @@
-(async () => {
-	const assert = require("assert");
-	const Date = require("../objects/date.js");
-	const range = (from, to) => [...new Array(to - from + 1)].map((i, ind) => ind + from);
+import assert from "assert";
+import SupiDate from "../objects/date.js";
+import UtilsConstructor from "../singletons/utils.js";
 
-	globalThis.sb = {
-		Config: {
-			get: () => null
+const range = (from, to) => [...new Array(to - from + 1)].map((i, ind) => ind + from);
+const Utils = new UtilsConstructor();
+
+describe("timeDelta", () => {
+	const MINUTE = 60_000;
+	const HOUR = 60 * MINUTE;
+	const DAY = 24 * HOUR;
+	const YEAR = 365 * DAY;
+
+	const timeDelta = (target, skipAffixes, respectLeapYears, deltaTo) => Utils.timeDelta(target, skipAffixes ?? false, respectLeapYears ?? false, deltaTo ?? new SupiDate(0));
+
+	it("checks types properly", () => {
+		assert.doesNotThrow(() => timeDelta(new Date()));
+		assert.doesNotThrow(() => timeDelta(new SupiDate()));
+		assert.doesNotThrow(() => timeDelta(12345));
+
+		const mockedNumberValueOf = { valueOf: () => 12345 };
+		assert.doesNotThrow(() => timeDelta(mockedNumberValueOf));
+
+		assert.throws(() => timeDelta(null));
+		assert.throws(() => timeDelta("string"));
+		assert.throws(() => timeDelta({}));
+		assert.throws(() => timeDelta([]));
+
+		const mockedStringValueOf = { valueOf: () => "string" };
+		assert.throws(() => timeDelta(mockedStringValueOf));
+	});
+
+	it("returns a special value for delta === 0", () => {
+		const date = new SupiDate(0);
+		assert.strictEqual(timeDelta(date), "right now!");
+	});
+
+	it("parses milliseconds-specific times properly", () => {
+		const futureDate = new SupiDate(10);
+		assert.strictEqual(timeDelta(futureDate), "in 10ms");
+		assert.strictEqual(timeDelta(futureDate, true), "10ms");
+
+		const pastDate = new SupiDate(-10);
+		assert.strictEqual(timeDelta(pastDate), "10ms ago");
+		assert.strictEqual(timeDelta(pastDate, true), "10ms");
+	});
+
+	it("parses seconds properly", () => {
+		for (let i = 1000; i < 60_000; i += 10) {
+			const futureDate = new SupiDate(i);
+			const expectedLongString = `in ${i / 1000}s`;
+			const expectedShortString = `${i / 1000}s`;
+
+			assert.strictEqual(timeDelta(futureDate), expectedLongString, `Input: ${i}`);
+			assert.strictEqual(timeDelta(futureDate, true), expectedShortString, `Input: ${i}`);
 		}
-	};
 
-	await require("../")("sb", {
-		whitelist: [
-			"singletons/utils"
-		]
+		for (let i = -1000; i > -60_000; i -= 50) {
+			const pastDate = new SupiDate(i);
+			const expectedLongString = `${Math.abs(i) / 1000}s ago`;
+			const expectedShortString = `${Math.abs(i) / 1000}s`;
+
+			assert.strictEqual(timeDelta(pastDate), expectedLongString, `Input: ${i}`);
+			assert.strictEqual(timeDelta(pastDate, true), expectedShortString, `Input: ${i}`);
+		}
 	});
 
-	sb.Date = Date;
-
-	describe("timeDelta", () => {
-		const MINUTE = 60_000;
-		const HOUR = 60 * MINUTE;
-		const DAY = 24 * HOUR;
-		const YEAR = 365 * DAY;
-
-		const timeDelta = (target, skipAffixes, respectLeapYears, deltaTo) => sb.Utils.timeDelta(target, skipAffixes ?? false, respectLeapYears ?? false, deltaTo ?? new sb.Date(0));
-
-		it("checks types properly", () => {
-			assert.doesNotThrow(() => timeDelta(new Date()));
-			assert.doesNotThrow(() => timeDelta(new sb.Date()));
-			assert.doesNotThrow(() => timeDelta(12345));
-
-			const mockedNumberValueOf = { valueOf: () => 12345 };
-			assert.doesNotThrow(() => timeDelta(mockedNumberValueOf));
-
-			assert.throws(() => timeDelta(null));
-			assert.throws(() => timeDelta("string"));
-			assert.throws(() => timeDelta({}));
-			assert.throws(() => timeDelta([]));
-
-			const mockedStringValueOf = { valueOf: () => "string" };
-			assert.throws(() => timeDelta(mockedStringValueOf));
-		});
-
-		it("returns a special value for delta === 0", () => {
-			const date = new sb.Date(0);
-			assert.strictEqual(timeDelta(date), "right now!");
-		});
-
-		it("parses milliseconds-specific times properly", () => {
-			const futureDate = new sb.Date(10);
-			assert.strictEqual(timeDelta(futureDate), "in 10ms");
-			assert.strictEqual(timeDelta(futureDate, true), "10ms");
-
-			const pastDate = new sb.Date(-10);
-			assert.strictEqual(timeDelta(pastDate), "10ms ago");
-			assert.strictEqual(timeDelta(pastDate, true), "10ms");
-		});
-
-		it("parses seconds properly", () => {
-			for (let i = 1000; i < 60_000; i += 10) {
-				const futureDate = new sb.Date(i);
-				const expectedLongString = `in ${i / 1000}s`;
-				const expectedShortString = `${i / 1000}s`;
-
-				assert.strictEqual(timeDelta(futureDate), expectedLongString, `Input: ${i}`);
-				assert.strictEqual(timeDelta(futureDate, true), expectedShortString, `Input: ${i}`);
-			}
-
-			for (let i = -1000; i > -60_000; i -= 50) {
-				const pastDate = new sb.Date(i);
-				const expectedLongString = `${Math.abs(i) / 1000}s ago`;
-				const expectedShortString = `${Math.abs(i) / 1000}s`;
-
-				assert.strictEqual(timeDelta(pastDate), expectedLongString, `Input: ${i}`);
-				assert.strictEqual(timeDelta(pastDate, true), expectedShortString, `Input: ${i}`);
-			}
-		});
-
-		it("rounds off milliseconds in context of seconds", () => {
-			// 29.995 through 30.004, all resulting in "30s"
-			const expectedLongString = "in 30s";
-			const expectedShortString = "30s";
-			const rounded = [29995, 29996, 29997, 29998, 29999, 30000, 30001, 30002, 30003, 30004];
-			for (const time of rounded) {
-				const date = new sb.Date(time);
-				assert.strictEqual(timeDelta(date), expectedLongString, `Input: ${time}`);
-				assert.strictEqual(timeDelta(date, true), expectedShortString, `Input: ${time}`);
-			}
-		});
-
-		it("parses minutes properly", () => {
-			const definition = [
-				[range(118500, 119499), "1m, 59s"],
-				[range(119500, 120499), "2m, 0s"]
-			];
-
-			for (const [range, string] of definition) {
-				for (const time of range) {
-					assert.strictEqual(
-						timeDelta(new sb.Date(time), true),
-						string,
-						`Input: ${time}`
-					);
-				}
-			}
-		});
-
-		it("parses hours properly", () => {
-			const definition = [
-				[range(7_199_000, 7_199_499), "1h, 59m"],
-				[range(7_199_500, 7_200_499), "2h, 0m"]
-			];
-
-			for (const [range, string] of definition) {
-				for (const time of range) {
-					assert.strictEqual(
-						timeDelta(new sb.Date(time), true),
-						string,
-						`Input: ${time}`
-					);
-				}
-			}
-		});
-
-		it("parses days properly", () => {
-			const definition = [
-				[range(48 * 3_600_000 - 1000, 48 * 3_600_000 - 501), "1d, 23h"],
-				[range(48 * 3_600_000 - 499, 48 * 3_600_000 + 499), "2d, 0h"]
-			];
-
-			for (const [range, string] of definition) {
-				for (const time of range) {
-					assert.strictEqual(
-						timeDelta(new sb.Date(time), true),
-						string,
-						`Input: ${time}`
-					);
-				}
-			}
-		});
-
-		it("parses higher values properly", () => {
-			const definition = [
-				[range(2 * YEAR - 999, 2 * YEAR + 999), "2y, 0d"],
-				[range(YEAR + 364 * DAY, YEAR + 364 * DAY + 999), "1y, 364d"]
-			];
-
-			for (const [range, string] of definition) {
-				for (const time of range) {
-					assert.strictEqual(
-						timeDelta(new sb.Date(time), true),
-						string,
-						`Input: ${time}`
-					);
-				}
-			}
-		});
-
-		it("shows leap years as 1y", () => {
-			// now is 2020-01-01, the date to calculate to is 2030-01-01
-			assert.strictEqual(
-				timeDelta(
-					new sb.Date("January 5, 2030 00:00:00 UTC"),
-					false,
-					true,
-					new sb.Date("January 1, 2020 00:00:00 UTC")
-				),
-				"in 10y, 4d"
-			);
-			// reverse
-			assert.strictEqual(
-				timeDelta(
-					new sb.Date("December 29, 2019 00:00:00 UTC"),
-					false,
-					true,
-					new sb.Date("January 1, 2030 00:00:00 UTC")
-				),
-				"10y, 3d ago"
-			);
-
-			// mode with leap year calculation disabled
-			assert.strictEqual(
-				timeDelta(
-					new sb.Date("January 1, 2030 00:00:00 UTC"),
-					true,
-					false,
-					new sb.Date("January 1, 2020 00:00:00 UTC")
-				),
-				"10y, 3d"
-			);
-		});
+	it("rounds off milliseconds in context of seconds", () => {
+		// 29.995 through 30.004, all resulting in "30s"
+		const expectedLongString = "in 30s";
+		const expectedShortString = "30s";
+		const rounded = [29995, 29996, 29997, 29998, 29999, 30000, 30001, 30002, 30003, 30004];
+		for (const time of rounded) {
+			const date = new SupiDate(time);
+			assert.strictEqual(timeDelta(date), expectedLongString, `Input: ${time}`);
+			assert.strictEqual(timeDelta(date, true), expectedShortString, `Input: ${time}`);
+		}
 	});
-})();
+
+	it("parses minutes properly", () => {
+		const definition = [
+			[range(118500, 119499), "1m, 59s"],
+			[range(119500, 120499), "2m, 0s"]
+		];
+
+		for (const [range, string] of definition) {
+			for (const time of range) {
+				assert.strictEqual(
+					timeDelta(new SupiDate(time), true),
+					string,
+					`Input: ${time}`
+				);
+			}
+		}
+	});
+
+	it("parses hours properly", () => {
+		const definition = [
+			[range(7_199_000, 7_199_499), "1h, 59m"],
+			[range(7_199_500, 7_200_499), "2h, 0m"]
+		];
+
+		for (const [range, string] of definition) {
+			for (const time of range) {
+				assert.strictEqual(
+					timeDelta(new SupiDate(time), true),
+					string,
+					`Input: ${time}`
+				);
+			}
+		}
+	});
+
+	it("parses days properly", () => {
+		const definition = [
+			[range(48 * 3_600_000 - 1000, 48 * 3_600_000 - 501), "1d, 23h"],
+			[range(48 * 3_600_000 - 499, 48 * 3_600_000 + 499), "2d, 0h"]
+		];
+
+		for (const [range, string] of definition) {
+			for (const time of range) {
+				assert.strictEqual(
+					timeDelta(new SupiDate(time), true),
+					string,
+					`Input: ${time}`
+				);
+			}
+		}
+	});
+
+	it("parses higher values properly", () => {
+		const definition = [
+			[range(2 * YEAR - 999, 2 * YEAR + 999), "2y, 0d"],
+			[range(YEAR + 364 * DAY, YEAR + 364 * DAY + 999), "1y, 364d"]
+		];
+
+		for (const [range, string] of definition) {
+			for (const time of range) {
+				assert.strictEqual(
+					timeDelta(new SupiDate(time), true),
+					string,
+					`Input: ${time}`
+				);
+			}
+		}
+	});
+
+	it("shows leap years as 1y", () => {
+		// now is 2020-01-01, the date to calculate to is 2030-01-01
+		assert.strictEqual(
+			timeDelta(
+				new SupiDate("January 5, 2030 00:00:00 UTC"),
+				false,
+				true,
+				new SupiDate("January 1, 2020 00:00:00 UTC")
+			),
+			"in 10y, 4d"
+		);
+		// reverse
+		assert.strictEqual(
+			timeDelta(
+				new SupiDate("December 29, 2019 00:00:00 UTC"),
+				false,
+				true,
+				new SupiDate("January 1, 2030 00:00:00 UTC")
+			),
+			"10y, 3d ago"
+		);
+
+		// mode with leap year calculation disabled
+		assert.strictEqual(
+			timeDelta(
+				new SupiDate("January 1, 2030 00:00:00 UTC"),
+				true,
+				false,
+				new SupiDate("January 1, 2020 00:00:00 UTC")
+			),
+			"10y, 3d"
+		);
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "node16",
     "target": "es2021",
     "sourceMap": true,
     "strictNullChecks": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,7 +1062,7 @@ domutils@^3.0.1:
 
 "duration-parser@github:supinic/duration-parser":
   version "1.0.0"
-  resolved "https://codeload.github.com/supinic/duration-parser/tar.gz/61a75c0fc41cd211ac284d5744628608b7f93617"
+  resolved "https://codeload.github.com/supinic/duration-parser/tar.gz/94d68f1b987c96d10c80bf8cb3a450401874e86a"
 
 electron-to-chromium@^1.4.477:
   version "1.4.522"
@@ -1861,7 +1861,7 @@ keyv@^4.0.0, keyv@^4.5.3:
 
 "language-iso-codes@github:supinic/language-iso-codes":
   version "1.0.0"
-  resolved "https://codeload.github.com/supinic/language-iso-codes/tar.gz/0bff9476cc5806d8ae970643b5b0583f6c4028ca"
+  resolved "https://codeload.github.com/supinic/language-iso-codes/tar.gz/dc0e75b4f40978d5549fcf1da5243687c8445963"
 
 levn@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Aims to simplify the inter-dependencies in `supi-core` by doing the following:
- remove the global `sb` variable, its creation, management, types, exports
- replace all `sb` accesses with local imports
- allow importing of specific modules as required
- shift the burden of initializing modules with specific options (e.g. `Cache` or `Query`) away from `supi-core`
- improve the type bindings, mostly for IDE usability